### PR TITLE
dec: derive Hash for exported Decimal\d* structs

### DIFF
--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -50,7 +50,7 @@ fn validate_n(n: usize) {
 /// at compile time, so they are checked at runtime.
 #[cfg_attr(docsrs, doc(cfg(feature = "arbitrary-precision")))]
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 pub struct Decimal<const N: usize> {
     digits: u32,
     exponent: i32,

--- a/dec/src/decimal128.rs
+++ b/dec/src/decimal128.rs
@@ -49,7 +49,7 @@ use crate::error::ParseDecimalError;
 /// context, which has some performance overhead. For maximum performance when
 /// performing operations in bulk, use a long-lived context that you construct
 /// yourself.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Hash)]
 pub struct Decimal128 {
     pub(crate) inner: decnumber_sys::decQuad,
 }

--- a/dec/src/decimal32.rs
+++ b/dec/src/decimal32.rs
@@ -28,7 +28,7 @@ use crate::decimal64::Decimal64;
 use crate::error::ParseDecimalError;
 
 /// A 32-bit decimal floating-point number.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Hash)]
 pub struct Decimal32 {
     pub(crate) inner: decnumber_sys::decSingle,
 }

--- a/dec/src/decimal64.rs
+++ b/dec/src/decimal64.rs
@@ -49,7 +49,7 @@ use crate::error::ParseDecimalError;
 /// context, which has some performance overhead. For maximum performance when
 /// performing operations in bulk, use a long-lived context that you construct
 /// yourself.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Hash)]
 pub struct Decimal64 {
     pub(crate) inner: decnumber_sys::decDouble,
 }

--- a/decnumber-sys/src/lib.rs
+++ b/decnumber-sys/src/lib.rs
@@ -1009,7 +1009,7 @@ extern "C" {
 }
 
 #[repr(C, align(4))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash)]
 pub struct decimal32 {
     pub bytes: [u8; 4usize],
 }
@@ -1045,7 +1045,7 @@ extern "C" {
 }
 
 #[repr(C, align(4))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash)]
 pub struct decimal64 {
     pub bytes: [u8; 8usize],
 }
@@ -1069,7 +1069,7 @@ extern "C" {
 }
 
 #[repr(C, align(4))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash)]
 pub struct decimal128 {
     pub bytes: [u8; 16usize],
 }


### PR DESCRIPTION
`ScalarType` in Materialize requires this trait