### PR TITLE
dec: implement Hash for Decimal64 and Decimal128

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog], and this crate adheres to [Semantic
 Versioning].
 
+## Unreleased
+
+* Add `Hash` implementations for `Decimal64` and `Decimal128`.
+
 ## 0.1.2 - 2020-02-01
 
 * Correct documentation links in README, again.

--- a/dec/src/decimal128.rs
+++ b/dec/src/decimal128.rs
@@ -16,6 +16,7 @@
 use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
@@ -346,6 +347,15 @@ impl PartialOrd for Decimal128 {
 impl Ord for Decimal128 {
     fn cmp(&self, other: &Self) -> Ordering {
         self.total_cmp(other)
+    }
+}
+
+impl Hash for Decimal128 {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.canonical().inner.bytes.hash(state)
     }
 }
 

--- a/dec/src/decimal64.rs
+++ b/dec/src/decimal64.rs
@@ -16,6 +16,7 @@
 use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
@@ -344,6 +345,15 @@ impl PartialOrd for Decimal64 {
 impl Ord for Decimal64 {
     fn cmp(&self, other: &Self) -> Ordering {
         self.total_cmp(other)
+    }
+}
+
+impl Hash for Decimal64 {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.canonical().inner.bytes.hash(state)
     }
 }
 

--- a/dectest/src/backend.rs
+++ b/dectest/src/backend.rs
@@ -16,6 +16,7 @@
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt;
+use std::hash::Hasher;
 
 use dec::{Class, Decimal128, Decimal32, Decimal64, Rounding, Status};
 
@@ -64,6 +65,7 @@ pub type BackendResult<T> = Result<T, BackendError>;
 pub trait Backend {
     type D: fmt::Display + Clone;
 
+    const HASHABLE: bool;
     const REPORTS_STATUS_CLAMPED: bool;
     const REPORTS_STATUS_ROUNDED: bool;
     const REPORTS_STATUS_SUBNORMAL: bool;
@@ -78,6 +80,9 @@ pub trait Backend {
     fn to_decimal32(&mut self, n: &Self::D) -> Decimal32;
     fn to_decimal64(&mut self, n: &Self::D) -> Decimal64;
     fn to_decimal128(&mut self, n: &Self::D) -> Decimal128;
+    fn hash<H>(n: &Self::D, state: &mut H)
+    where
+        H: Hasher;
 
     fn status(&self) -> Status;
     fn clear_status(&mut self);

--- a/dectest/src/backend/decimal.rs
+++ b/dectest/src/backend/decimal.rs
@@ -14,6 +14,7 @@
 // limitations under the License
 
 use std::cmp::Ordering;
+use std::hash::Hasher;
 use std::str::FromStr;
 
 use dec::{Class, Context, Decimal, Decimal128, Decimal32, Decimal64, Rounding, Status};
@@ -30,6 +31,7 @@ pub struct DecimalBackend {
 impl Backend for DecimalBackend {
     type D = Decimal<N>;
 
+    const HASHABLE: bool = false;
     const REPORTS_STATUS_CLAMPED: bool = true;
     const REPORTS_STATUS_ROUNDED: bool = true;
     const REPORTS_STATUS_SUBNORMAL: bool = true;
@@ -80,6 +82,13 @@ impl Backend for DecimalBackend {
 
     fn to_decimal128(&mut self, n: &Self::D) -> Decimal128 {
         n.to_decimal128()
+    }
+
+    fn hash<H>(_: &Self::D, _: &mut H)
+    where
+        H: Hasher,
+    {
+        unimplemented!("Decimal does not implement Hash")
     }
 
     fn status(&self) -> Status {

--- a/dectest/src/backend/decimal128.rs
+++ b/dectest/src/backend/decimal128.rs
@@ -14,6 +14,7 @@
 // limitations under the License
 
 use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 use dec::{Class, Context, Decimal128, Decimal32, Decimal64, Rounding, Status};
@@ -27,6 +28,7 @@ pub struct Decimal128Backend {
 impl Backend for Decimal128Backend {
     type D = Decimal128;
 
+    const HASHABLE: bool = true;
     const REPORTS_STATUS_CLAMPED: bool = false;
     const REPORTS_STATUS_ROUNDED: bool = false;
     const REPORTS_STATUS_SUBNORMAL: bool = false;
@@ -71,6 +73,13 @@ impl Backend for Decimal128Backend {
 
     fn to_decimal128(&mut self, n: &Self::D) -> Decimal128 {
         *n
+    }
+
+    fn hash<H>(n: &Self::D, state: &mut H)
+    where
+        H: Hasher,
+    {
+        n.hash(state)
     }
 
     fn status(&self) -> Status {

--- a/dectest/src/backend/decimal32.rs
+++ b/dectest/src/backend/decimal32.rs
@@ -14,6 +14,7 @@
 // limitations under the License
 
 use std::cmp::Ordering;
+use std::hash::Hasher;
 use std::str::FromStr;
 
 use dec::{Class, Context, Decimal128, Decimal32, Decimal64, Rounding, Status};
@@ -27,6 +28,7 @@ pub struct Decimal32Backend {
 impl Backend for Decimal32Backend {
     type D = Decimal32;
 
+    const HASHABLE: bool = false;
     const REPORTS_STATUS_CLAMPED: bool = false;
     const REPORTS_STATUS_ROUNDED: bool = false;
     const REPORTS_STATUS_SUBNORMAL: bool = false;
@@ -71,6 +73,13 @@ impl Backend for Decimal32Backend {
 
     fn to_decimal128(&mut self, n: &Self::D) -> Decimal128 {
         Decimal128::from(*n)
+    }
+
+    fn hash<H>(_: &Self::D, _: &mut H)
+    where
+        H: Hasher,
+    {
+        unimplemented!("Decimal32 does not implement Hash")
     }
 
     fn status(&self) -> Status {

--- a/dectest/src/backend/decimal64.rs
+++ b/dectest/src/backend/decimal64.rs
@@ -14,6 +14,7 @@
 // limitations under the License
 
 use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 use dec::{Class, Context, Decimal128, Decimal32, Decimal64, Rounding, Status};
@@ -27,6 +28,7 @@ pub struct Decimal64Backend {
 impl Backend for Decimal64Backend {
     type D = Decimal64;
 
+    const HASHABLE: bool = true;
     const REPORTS_STATUS_CLAMPED: bool = false;
     const REPORTS_STATUS_ROUNDED: bool = false;
     const REPORTS_STATUS_SUBNORMAL: bool = false;
@@ -70,6 +72,13 @@ impl Backend for Decimal64Backend {
 
     fn to_decimal128(&mut self, n: &Self::D) -> Decimal128 {
         Decimal128::from(*n)
+    }
+
+    fn hash<H>(n: &Self::D, state: &mut H)
+    where
+        H: Hasher,
+    {
+        n.hash(state)
     }
 
     fn status(&self) -> Status {


### PR DESCRIPTION
Canonicalizing Decimal64 and Decimal128 then directly hashing the bytes
seems to produce a valid Hash implementation for these types.
Specifically, the test runner does not find any cases where the Eq
and Hash implementations of these types disagree.

Decimal32 does not support canonicalization and therefore does not
support hashing.

It is not clear to me at all how to make Decimal<N> support hashing,
since a stable representation requires rescaling which can require a
potentially arbitrary amount of space.

Co-authored-by: Nikhil Benesch <nikhil.benesch@gmail.com>