### PR TITLE
dec: add boilerplate impls to OrderedDecimal<D>

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -9,16 +9,29 @@ Versioning].
 
 * Add the `OrderedDecimal` wrapper type to imbue `Decimal64` and `Decimal128`
   with implementations of `Ord` and `Hash`, akin to
-  `ordered_float::OrderedFloat`.
+  `ordered_float::OrderedFloat`. The order used is that of the underlying type's
+  `partial_cmp`, except that NaNs are considered equal to themselves and sort
+  greater than all other values.
 
-* Add associated constants for zero and NaN to each floating-point decimal
+* Remove the `Ord` and `Eq` implementations from `Decimal64` and `Decimal128`,
+  which used `total_cmp`'s order.
+
+* Change the `PartialCmp` and `PartialEq` implementations of `Decimal64` and
+  `Decimal128` to use the semantics of `Context::<D>::partial_cmp` rather than
+  `D::total_cmp`. This is analogous to the behavior of the primitive `f32` and
+  `f64` types.
+
+* Add associated constants for zero, one, and NaN to each floating-point decimal
   type. The full list of added constants is:
 
   * `Decimal32::ZERO`
+  * `Decimal32::ONE`
   * `Decimal32::NAN`
   * `Decimal64::ZERO`
+  * `Decimal64::ONE`
   * `Decimal64::NAN`
   * `Decimal128::ZERO`
+  * `Decimal128::ONE`
   * `Decimal128::NAN`
 
 * Remove the `Decimal32::zero`, `Decimal64::zero`, and `Decimal128::zero`
@@ -27,6 +40,9 @@ Versioning].
 
 * Mark `Decimal32::from_ne_bytes`, `Decimal64::from_ne_bytes`, and
   `Decimal128::from_ne_bytes` as `const fn`s.
+
+* Add `std::iter::Sum` and `std::iter::Product` implementations for `Decimal64`
+  and `Decimal128`.
 
 ## 0.1.2 - 2020-02-01
 

--- a/dec/src/decimal32.rs
+++ b/dec/src/decimal32.rs
@@ -48,6 +48,13 @@ impl Decimal32 {
         [0x22, 0x50, 0x0, 0x0]
     });
 
+    /// The value that represents one.
+    pub const ONE: Decimal32 = Decimal32::from_ne_bytes(if cfg!(target_endian = "little") {
+        [0x1, 0x0, 0x50, 0x22]
+    } else {
+        [0x22, 0x50, 0x0, 0x1]
+    });
+
     /// Creates a number from its representation as a little-endian byte array.
     pub fn from_le_bytes(mut bytes: [u8; 4]) -> Decimal32 {
         if cfg!(target_endian = "big") {

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -15,7 +15,12 @@
 
 use std::cmp::Ordering;
 use std::error::Error;
+use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::iter::{Product, Sum};
+use std::ops::{
+    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
+};
 
 use dec::{Decimal128, Decimal32, Decimal64, OrderedDecimal};
 
@@ -97,6 +102,7 @@ fn test_ordered_decimal128() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_constants_decimal32() -> Result<(), Box<dyn Error>> {
     assert_eq!(Decimal32::ZERO.to_string(), "0");
+    assert_eq!(Decimal32::ONE.to_string(), "1");
     assert_eq!(Decimal32::NAN.to_string(), "NaN");
     Ok(())
 }
@@ -104,6 +110,7 @@ fn test_constants_decimal32() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_constants_decimal64() -> Result<(), Box<dyn Error>> {
     assert_eq!(Decimal64::ZERO.to_string(), "0");
+    assert_eq!(Decimal64::ONE.to_string(), "1");
     assert_eq!(Decimal64::NAN.to_string(), "NaN");
     Ok(())
 }
@@ -111,6 +118,89 @@ fn test_constants_decimal64() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_constants_decimal128() -> Result<(), Box<dyn Error>> {
     assert_eq!(Decimal128::ZERO.to_string(), "0");
+    assert_eq!(Decimal128::ONE.to_string(), "1");
     assert_eq!(Decimal128::NAN.to_string(), "NaN");
+    Ok(())
+}
+
+#[test]
+fn test_overloading() -> Result<(), Box<dyn Error>> {
+    // The goal here is only to test that the traits are wired up correctly,
+    // e.g., to protect against transcription errors. The correctness of the
+    // actual arithmetic operations is checked extensively by dectest.
+
+    fn inner<T1, T2>() -> Result<(), Box<dyn Error>>
+    where
+        T1: Neg<Output = T1>
+            + Add<T2, Output = T1>
+            + Sub<T2, Output = T1>
+            + Mul<T2, Output = T1>
+            + Div<T2, Output = T1>
+            + Rem<T2, Output = T1>
+            + AddAssign
+            + SubAssign
+            + MulAssign
+            + DivAssign
+            + RemAssign
+            + Sum
+            + for<'a> Sum<&'a T1>
+            + Product
+            + for<'a> Product<&'a T1>
+            + Product
+            + PartialEq
+            + From<i32>
+            + fmt::Debug,
+        T2: From<i32>,
+    {
+        let t1 = |t| T1::from(t);
+        let t2 = |t| T2::from(t);
+
+        assert_eq!(-t1(1), t1(-1));
+        assert_eq!(t1(1) + t2(2), t1(3));
+        assert_eq!(t1(3) - t2(2), t1(1));
+        assert_eq!(t1(2) * t2(3), t1(6));
+        assert_eq!(t1(10) / t2(2), t1(5));
+        assert_eq!(t1(10) % t2(3), t1(1));
+
+        let mut x = t1(1);
+        x += t1(2);
+        assert_eq!(x, t1(3));
+
+        let mut x = t1(3);
+        x -= t1(2);
+        assert_eq!(x, t1(1));
+
+        let mut x = t1(2);
+        x *= t1(3);
+        assert_eq!(x, t1(6));
+
+        let mut x = t1(10);
+        x /= t1(2);
+        assert_eq!(x, t1(5));
+
+        let mut x = t1(10);
+        x %= t1(3);
+        assert_eq!(x, t1(1));
+
+        assert_eq!([t1(2), t1(2), t1(3)].iter().sum::<T1>(), t1(7));
+        assert_eq!(vec![t1(2), t1(2), t1(3)].into_iter().sum::<T1>(), t1(7));
+
+        assert_eq!([t1(2), t1(2), t1(3)].iter().product::<T1>(), t1(12));
+        assert_eq!(
+            vec![t1(2), t1(2), t1(3)].into_iter().product::<T1>(),
+            t1(12)
+        );
+
+        Ok(())
+    }
+
+    inner::<Decimal64, Decimal64>()?;
+    inner::<Decimal128, Decimal128>()?;
+    inner::<OrderedDecimal<Decimal64>, OrderedDecimal<Decimal64>>()?;
+    inner::<OrderedDecimal<Decimal64>, Decimal64>()?;
+    inner::<OrderedDecimal<Decimal128>, Decimal128>()?;
+    inner::<Decimal64, OrderedDecimal<Decimal64>>()?;
+    inner::<Decimal128, OrderedDecimal<Decimal128>>()?;
+
     Ok(())
 }


### PR DESCRIPTION
@benesch I looked into implementing `Context<OrderedDecimal<D>>`, as well, but figured this was a reasonable place to start.