### PR TITLE
dec: support cast from i/u64 to Decimal64/128 + i/u128 to Decimal128

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog], and this crate adheres to [Semantic
 Versioning].
 
-## 0.2.0 - 2020-02-03
+## Unreleased
+
+* Implement `From<i64>` and `From<u64>` for `Decimal128`.
+
+* Add the `from_i64` and `from_u64` methods to `Context<Decimal64>`, which
+  provide inexact conversions from `i64` and `u64`, respectively, to
+  `Decimal64`.
+
+* Add the `from_i128` and `from_u128` methods to `Context<Decimal128>`, which
+  provide inexact conversions from `i128` and `u128`, respectively, to
+  `Decimal128`.
+
+## 0.2.0 - 2021-02-03
 
 * Add the `OrderedDecimal` wrapper type which imbues `Decimal64` and
   `Decimal128` with implementations of `Ord` and `Hash`, akin to
@@ -44,17 +56,17 @@ Versioning].
 * Add `std::iter::Sum` and `std::iter::Product` implementations for `Decimal64`
   and `Decimal128`.
 
-## 0.1.2 - 2020-02-01
+## 0.1.2 - 2021-02-01
 
 * Correct documentation links in README, again.
 
-## 0.1.1 - 2020-02-01
+## 0.1.1 - 2021-02-01
 
 * Correct documentation links in README.
 * Implement `Hash` for the `Class`, `Rounding` and `Status` types.
 * Include fields in `fmt::Debug` output for `Status`.
 
-## 0.1.0 - 2020-01-31
+## 0.1.0 - 2021-01-31
 
 Initial release.
 

--- a/dec/src/conv.rs
+++ b/dec/src/conv.rs
@@ -1,0 +1,54 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Converts from some arbitrary signed integer `$n` whose size is a multiple of
+/// 32 into a decimal of type `$t`.
+///
+/// `$cx` is a `Context::<$t>` used to generate a value of `$t`. It must outlive
+/// the macro call to, e.g., allow checking the context's status.
+macro_rules! from_signed_int {
+    ($t:ty, $cx:expr, $n:expr) => {
+        __from_int!($t, i32, $cx, $n)
+    };
+}
+
+/// Like `from_signed_int!` but for unsigned integers.
+macro_rules! from_unsigned_int {
+    ($t:ty, $cx:expr, $n:expr) => {
+        __from_int!($t, u32, $cx, $n)
+    };
+}
+
+macro_rules! __from_int {
+    ($t:ty, $l:ty, $cx:expr, $n:expr) => {{
+        let n = $n.to_be_bytes();
+        assert!(
+            n.len() % 4 == 0 && n.len() >= 4,
+            "from_int requires size of integer to be a multiple of 32"
+        );
+
+        // Process `$n` in 32-bit chunks. Only the first chunk has to be sign
+        // aware. Each turn of the loop computes `d = d * 2^32 + n`, where `n`
+        // is the next 32-bit chunk.
+        let mut d = <$t>::from(<$l>::from_be_bytes(n[..4].try_into().unwrap()));
+        for i in (4..n.len()).step_by(4) {
+            d = $cx.mul(d, <$t>::TWO_POW_32);
+            let n = <$t>::from(u32::from_be_bytes(n[i..i + 4].try_into().unwrap()));
+            d = $cx.add(d, n);
+        }
+
+        d
+    }};
+}

--- a/dec/src/lib.rs
+++ b/dec/src/lib.rs
@@ -97,6 +97,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod context;
+#[macro_use]
+mod conv;
 #[cfg(feature = "arbitrary-precision")]
 #[cfg_attr(docsrs, doc(cfg(feature = "arbitrary-precision")))]
 mod decimal;
@@ -105,6 +107,8 @@ mod decimal32;
 mod decimal64;
 mod error;
 mod ordered;
+#[cfg(tests)]
+mod tests;
 
 pub use context::{Class, Context, Rounding, Status};
 #[cfg(feature = "arbitrary-precision")]

--- a/dec/src/tests.rs
+++ b/dec/src/tests.rs
@@ -1,0 +1,19 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn test_private_constants() {
+    assert_eq!(Decimal64::TWO_POW_32.to_string(), "4294967296");
+    assert_eq!(Decimal128::TWO_POW_32.to_string(), "4294967296");
+}

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -22,7 +22,7 @@ use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
-use dec::{Decimal128, Decimal32, Decimal64, OrderedDecimal};
+use dec::{Context, Decimal128, Decimal32, Decimal64, OrderedDecimal};
 
 #[derive(Default)]
 struct ValidatingHasher {
@@ -48,7 +48,7 @@ where
     hasher.bytes
 }
 
-const TESTS: &[(&str, &str, Ordering)] = &[
+const ORDERING_TESTS: &[(&str, &str, Ordering)] = &[
     ("1.2", "1.2", Ordering::Equal),
     ("1.2", "1.200", Ordering::Equal),
     ("1", "2", Ordering::Less),
@@ -67,7 +67,7 @@ const TESTS: &[(&str, &str, Ordering)] = &[
 
 #[test]
 fn test_ordered_decimal64() -> Result<(), Box<dyn Error>> {
-    for (lhs, rhs, expected) in TESTS {
+    for (lhs, rhs, expected) in ORDERING_TESTS {
         println!("cmp({}, {}): expected {:?}", lhs, rhs, expected);
         let lhs: OrderedDecimal<Decimal64> = OrderedDecimal(lhs.parse()?);
         let rhs: OrderedDecimal<Decimal64> = OrderedDecimal(rhs.parse()?);
@@ -84,7 +84,7 @@ fn test_ordered_decimal64() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_ordered_decimal128() -> Result<(), Box<dyn Error>> {
-    for (lhs, rhs, expected) in TESTS {
+    for (lhs, rhs, expected) in ORDERING_TESTS {
         println!("cmp({}, {}): expected {:?}", lhs, rhs, expected);
         let lhs: OrderedDecimal<Decimal128> = OrderedDecimal(lhs.parse()?);
         let rhs: OrderedDecimal<Decimal128> = OrderedDecimal(rhs.parse()?);
@@ -201,6 +201,187 @@ fn test_overloading() -> Result<(), Box<dyn Error>> {
     inner::<OrderedDecimal<Decimal128>, Decimal128>()?;
     inner::<Decimal64, OrderedDecimal<Decimal64>>()?;
     inner::<Decimal128, OrderedDecimal<Decimal128>>()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_i64_to_decimal128() -> Result<(), Box<dyn Error>> {
+    for &t in &[
+        0,
+        1i64,
+        -1i64,
+        i64::MAX,
+        i64::MIN,
+        i64::MAX / 2,
+        i64::MIN / 2,
+    ] {
+        assert_eq!(Decimal128::from(t).to_string(), t.to_string());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_u64_to_decimal128() -> Result<(), Box<dyn Error>> {
+    for &t in &[0, 1u64, u64::MAX, u64::MIN, u64::MAX / 2, u64::MIN / 2] {
+        assert_eq!(Decimal128::from(t).to_string(), t.to_string());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_i128_to_decimal128() -> Result<(), Box<dyn Error>> {
+    for &(input, output, inexact) in &[
+        (1i128, "1", false),
+        (-1i128, "-1", false),
+        (i128::from(i64::MAX), "9223372036854775807", false),
+        (i128::from(i64::MIN), "-9223372036854775808", false),
+        (i128::MAX, "1.701411834604692317316873037158841E+38", true),
+        (i128::MIN, "-1.701411834604692317316873037158841E+38", true),
+        // +34 places is exact.
+        (
+            i128::MAX / 100000,
+            "1701411834604692317316873037158841",
+            false,
+        ),
+        (
+            9_999_999_999_999_999_999_999_999_999_999_999i128,
+            "9999999999999999999999999999999999",
+            false,
+        ),
+        // +35 places places can be inexact.
+        (
+            i128::MAX / 10000,
+            "1.701411834604692317316873037158841E+34",
+            true,
+        ),
+        // +35 places can be exact.
+        (
+            10_000_000_000_000_000_000_000_000_000_000_000i128,
+            "1.000000000000000000000000000000000E+34",
+            false,
+        ),
+        // -34 places is exact.
+        (
+            i128::MIN / 100000,
+            "-1701411834604692317316873037158841",
+            false,
+        ),
+        (
+            -9_999_999_999_999_999_999_999_999_999_999_999i128,
+            "-9999999999999999999999999999999999",
+            false,
+        ),
+        // -35 places can be inexact.
+        (
+            i128::MIN / 10000,
+            "-1.701411834604692317316873037158841E+34",
+            true,
+        ),
+        // -35 places can be exact.
+        (
+            -10_000_000_000_000_000_000_000_000_000_000_000i128,
+            "-1.000000000000000000000000000000000E+34",
+            false,
+        ),
+    ] {
+        let mut cx = Context::<Decimal128>::default();
+        let d = cx.from_i128(input).to_string();
+        assert_eq!(d.to_string(), output);
+        assert_eq!(cx.status().inexact(), inexact);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_u128_to_decimal128() -> Result<(), Box<dyn Error>> {
+    for &(input, output, exact) in &[
+        (1u128, "1", false),
+        (u128::MAX, "3.402823669209384634633746074317682E+38", true),
+        (u128::MIN, "0", false),
+        // 34 places is exact.
+        (
+            u128::MAX / 100000,
+            "3402823669209384634633746074317682",
+            false,
+        ),
+        (
+            9_999_999_999_999_999_999_999_999_999_999_999u128,
+            "9999999999999999999999999999999999",
+            false,
+        ),
+        // 35 places can be exact.
+        (
+            10_000_000_000_000_000_000_000_000_000_000_000u128,
+            "1.000000000000000000000000000000000E+34",
+            false,
+        ),
+        // 35 places can be inexact.
+        (
+            10_000_000_000_000_000_000_000_000_000_000_001u128,
+            "1.000000000000000000000000000000000E+34",
+            true,
+        ),
+    ] {
+        let mut cx = Context::<Decimal128>::default();
+        let d = cx.from_u128(input).to_string();
+        assert_eq!(d.to_string(), output);
+        assert_eq!(cx.status().inexact(), exact);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_i64_to_decimal64() -> Result<(), Box<dyn Error>> {
+    for &(input, output, inexact) in &[
+        (1i64, "1", false),
+        (-1i64, "-1", false),
+        (i64::MAX, "9.223372036854776E+18", true),
+        (i64::MIN, "-9.223372036854776E+18", true),
+        (i64::MAX / 2, "4.611686018427388E+18", true),
+        (i64::MIN / 2, "-4.611686018427388E+18", true),
+        // +16 places is exact.
+        (i64::MAX / 1000, "9223372036854775", false),
+        (9_999_999_999_999_999i64, "9999999999999999", false),
+        // +17 places can be exact.
+        (1_000_0000_000_000_000i64, "1.000000000000000E+16", false),
+        // +17 places can be inexact.
+        (i64::MAX / 100, "9.223372036854776E+16", true),
+        // -15 places is exact.
+        (i64::MIN / 10000, "-922337203685477", false),
+        (-999_999_999_999_999i64, "-999999999999999", false),
+        // -16 places can be exact.
+        (i64::MIN / 1000, "-9223372036854775", false),
+        // -16 places can be inexact.
+        (-9_999_999_999_999_999i64, "-9999999999999997", true),
+    ] {
+        let mut cx = Context::<Decimal64>::default();
+        let d = cx.from_i64(input).to_string();
+        assert_eq!(d.to_string(), output);
+        assert_eq!(cx.status().inexact(), inexact);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_u64_to_decimal64() -> Result<(), Box<dyn Error>> {
+    for &(input, output, inexact) in &[
+        (1u64, "1", false),
+        (u64::MAX, "1.844674407370955E+19", true),
+        (u64::MIN, "0", false),
+        // 16 digits is exact.
+        (u64::MAX / 10000, "1844674407370955", false),
+        (9_999_999_999_999_999u64, "9999999999999999", false),
+        // 17 digits can be exact.
+        (10_000_000_000_000_000u64, "1.000000000000000E+16", false),
+        // 17 digits can be inexact.
+        (u64::MAX / 1000, "1.844674407370955E+16", true),
+    ] {
+        let mut cx = Context::<Decimal64>::default();
+        let d = cx.from_u64(input).to_string();
+        assert_eq!(d.to_string(), output);
+        assert_eq!(cx.status().inexact(), inexact);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Converting from 64- and 128-bit ints to `Decimal128` greatly simplifies code within Materialize, and provides library-level support for users who might want to accomplish the same thing.

@benesch I tried making `from_int_gt_32_bits` into a function using generics in lieu of the `$ty` parameters on the macro, but getting it to work required implementing some traits that were more code than felt worthwhile. lmk if this approach suffices, or if you either understand a way to implement this without traits, or if you'd prefer a trait-ed function.