### PR TITLE
dec: refactor to_standard_notation_string

### DIFF
--- a/dec/benches/dec.rs
+++ b/dec/benches/dec.rs
@@ -63,10 +63,52 @@ pub fn bench_to_string(d: Decimal128, b: &mut Bencher) {
     )
 }
 
+pub fn bench_to_string_64(d: Decimal64, b: &mut Bencher) {
+    b.iter_with_setup(
+        || {
+            let mut cx = Context::<Decimal64>::default();
+            [-50, 0, 50]
+                .iter()
+                .map(|exp| {
+                    let mut d = d.clone();
+                    cx.set_exponent(&mut d, *exp);
+                    d
+                })
+                .collect::<Vec<_>>()
+        },
+        |d| {
+            for d in d {
+                d.to_string();
+            }
+        },
+    )
+}
+
 pub fn bench_standard_notation_string(d: Decimal128, b: &mut Bencher) {
     b.iter_with_setup(
         || {
             let mut cx = Context::<Decimal128>::default();
+            [-50, 0, 50]
+                .iter()
+                .map(|exp| {
+                    let mut d = d.clone();
+                    cx.set_exponent(&mut d, *exp);
+                    d
+                })
+                .collect::<Vec<_>>()
+        },
+        |d| {
+            for d in d {
+                d.to_standard_notation_string();
+            }
+        },
+    )
+}
+
+pub fn bench_standard_notation_string_64(d: Decimal64, b: &mut Bencher) {
+    b.iter_with_setup(
+        || {
+            let mut cx = Context::<Decimal64>::default();
             [-50, 0, 50]
                 .iter()
                 .map(|exp| {
@@ -94,6 +136,16 @@ pub fn bench_print(c: &mut Criterion) {
     let d128 = cx.from_i128(rng.gen());
     c.bench_function("to_standard_notation_string_dec128", |b| {
         bench_standard_notation_string(d128, b)
+    });
+    let mut rng = thread_rng();
+    let mut cx = Context::<Decimal64>::default();
+    let d64 = cx.from_i64(rng.gen());
+    c.bench_function("to_string_dec64", |b| bench_to_string_64(d64.clone(), b));
+    let mut rng = thread_rng();
+    let mut cx = Context::<Decimal64>::default();
+    let d64 = cx.from_i64(rng.gen());
+    c.bench_function("to_standard_notation_string_dec64", |b| {
+        bench_standard_notation_string_64(d64, b)
     });
 }
 

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -840,7 +840,13 @@ fn test_standard_notation_dec_64() {
         for t in tests {
             cx.set_exponent(&mut d, t.0);
             assert_eq!(t.1, d.to_string());
-            assert_eq!(t.2, d.to_standard_notation_string());
+            assert_eq!(
+                t.2,
+                d.to_standard_notation_string(),
+                "{} should render {} as its standard notation string",
+                d,
+                t.2
+            );
         }
     }
 


### PR DESCRIPTION
Implements a more faithful transliteration of the `libdecnumber` printing functions (e.g. [`decimal64ToString`](https://github.com/MaterializeInc/rust-dec/blob/master/decnumber-sys/decnumber/decimal64.c#L285)) adapted for standard notation.

@benesch Only a performance improvement,  but now has benchmark parity with the underlying C library so think it's a nice win.

cc @elindsey just because you expressed some interest in seeing the problem