### PR TITLE
Support many new functions to make Decimal<N> usable

### DIFF
--- a/dec/Cargo.toml
+++ b/dec/Cargo.toml
@@ -14,11 +14,13 @@ edition = "2018"
 [dependencies]
 decnumber-sys = { version = "0.1.5", path = "../decnumber-sys" }
 libc = "0.2.82"
+serde = { version = "1.0.124", features = ["derive"] }
 static_assertions = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
 rand = "0.7.3"
+serde_test = "1.0.117"
 
 [features]
 arbitrary-precision = ["static_assertions"]

--- a/dec/src/context.rs
+++ b/dec/src/context.rs
@@ -73,6 +73,11 @@ impl<D> Context<D> {
         }
     }
 
+    /// Adds the given status to `self`.
+    pub fn add_status(&mut self, status: Status) {
+        self.inner.status |= status.inner
+    }
+
     /// Clears the context's status.
     pub fn clear_status(&mut self) {
         self.inner.status = 0;

--- a/dec/src/conv.rs
+++ b/dec/src/conv.rs
@@ -53,6 +53,39 @@ macro_rules! __from_int {
     }};
 }
 
+macro_rules! decnum_from_signed_int {
+    ($t:ty, $cx:expr, $n:expr) => {
+        __decnum_from_int!($t, i32, $cx, $n)
+    };
+}
+
+macro_rules! decnum_from_unsigned_int {
+    ($t:ty, $cx:expr, $n:expr) => {
+        __decnum_from_int!($t, u32, $cx, $n)
+    };
+}
+
+// Equivalent to `__from_int`, but with `Decimal`'s API.
+macro_rules! __decnum_from_int {
+    ($t:ty, $l:ty, $cx:expr, $n:expr) => {{
+        let n = $n.to_be_bytes();
+        assert!(
+            n.len() % 4 == 0 && n.len() >= 4,
+            "from_int requires size of integer to be a multiple of 32"
+        );
+        let two_pow_32 = Decimal::<N>::two_pow_32();
+
+        let mut d = <$t>::from(<$l>::from_be_bytes(n[..4].try_into().unwrap()));
+        for i in (4..n.len()).step_by(4) {
+            $cx.mul(&mut d, &two_pow_32);
+            let n = <$t>::from(u32::from_be_bytes(n[i..i + 4].try_into().unwrap()));
+            $cx.add(&mut d, &n);
+        }
+
+        d
+    }};
+}
+
 /// Converts from some decimal into a string in standard notation.
 macro_rules! to_standard_notation_string {
     ($d:expr) => {{

--- a/dec/src/conv.rs
+++ b/dec/src/conv.rs
@@ -53,12 +53,14 @@ macro_rules! __from_int {
     }};
 }
 
+#[cfg(feature = "arbitrary-precision")]
 macro_rules! decnum_from_signed_int {
     ($t:ty, $cx:expr, $n:expr) => {
         __decnum_from_int!($t, i32, $cx, $n)
     };
 }
 
+#[cfg(feature = "arbitrary-precision")]
 macro_rules! decnum_from_unsigned_int {
     ($t:ty, $cx:expr, $n:expr) => {
         __decnum_from_int!($t, u32, $cx, $n)

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -67,6 +67,20 @@ impl<const N: usize> Decimal<N> {
         self as *mut Decimal<N> as *mut decnumber_sys::decNumber
     }
 
+    /// Constructs a decimal number representing an infinite value.
+    pub fn infinity() -> Decimal<N> {
+        let mut d = Decimal::default();
+        d.bits = decnumber_sys::DECINF;
+        d
+    }
+
+    /// Constructs a decimal number representing a non-signaling NaN.
+    pub fn nan() -> Decimal<N> {
+        let mut d = Decimal::default();
+        d.bits = decnumber_sys::DECNAN;
+        d
+    }
+
     /// Constructs a decimal number with `N / 3` digits of precision
     /// representing the number 0.
     pub fn zero() -> Decimal<N> {

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -55,7 +55,7 @@ fn validate_n(n: usize) {
 /// at compile time, so they are checked at runtime.
 #[cfg_attr(docsrs, doc(cfg(feature = "arbitrary-precision")))]
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Hash)]
 pub struct Decimal<const N: usize> {
     digits: u32,
     exponent: i32,
@@ -259,6 +259,18 @@ impl<const N: usize> Default for Decimal<N> {
             decnumber_sys::decNumberZero(d.as_mut_ptr() as *mut decnumber_sys::decNumber);
             d.assume_init()
         }
+    }
+}
+
+impl<const N: usize> PartialOrd for Decimal<N> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Context::<Decimal<N>>::default().partial_cmp(self, other)
+    }
+}
+
+impl<const N: usize> PartialEq for Decimal<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
     }
 }
 

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -106,6 +106,18 @@ impl<const N: usize> Decimal<N> {
         self.digits
     }
 
+    /// Returns the individual digits of the coefficient in 8-bit, unpacked
+    /// [binary-coded decimal][bcd] format.
+    ///
+    /// [bcd]: https://en.wikipedia.org/wiki/Binary-coded_decimal
+    pub fn coefficient_digits(&self) -> Vec<u8> {
+        let mut buf = vec![0; usize::try_from(self.digits()).unwrap()];
+        unsafe {
+            decnumber_sys::decNumberGetBCD(self.as_ptr(), buf.as_mut_ptr() as *mut u8);
+        };
+        buf
+    }
+
     /// Computes the exponent of the number.
     pub fn exponent(&self) -> i32 {
         self.exponent
@@ -227,6 +239,12 @@ impl<const N: usize> Decimal<N> {
     /// The meaning of these parts are unspecified and subject to change.
     pub fn to_raw_parts(&self) -> (u32, i32, u8, [u16; N]) {
         (self.digits, self.exponent, self.bits, self.lsu)
+    }
+
+    /// Returns a string of the number in standard notation, i.e. guaranteed to
+    /// not be scientific notation.
+    pub fn to_standard_notation_string(&self) -> String {
+        to_standard_notation_string!(self)
     }
 }
 

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -100,6 +100,21 @@ impl<const N: usize> Decimal<N> {
         self.exponent
     }
 
+    /// Computes the number of digits necessary in standard notation to
+    /// represent `self`, not including any leading zeroes.
+    pub fn precision(&self) -> u64 {
+        if self.exponent >= 0 {
+            // More zeroes than digits, so dominates precision
+            u64::from(self.digits) + u64::try_from(self.exponent.abs()).unwrap()
+        } else if self.exponent.abs() as usize > self.digits() as usize {
+            // Negative exponent dominates digits, so is left-padded by zeroes
+            u64::try_from(self.exponent.abs()).unwrap()
+        } else {
+            // Decimal point splices digits
+            u64::from(self.digits)
+        }
+    }
+
     /// Reports whether the number is finite.
     ///
     /// A finite number is one that is neither infinite nor a NaN.

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -1187,6 +1187,18 @@ impl<const N: usize> Context<Decimal<N>> {
         }
     }
 
+    /// Rescales `n` to have an exponent of `exp`.
+    pub fn rescale(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<N>) {
+        unsafe {
+            decnumber_sys::decNumberRescale(
+                lhs.as_mut_ptr(),
+                lhs.as_ptr(),
+                rhs.as_ptr(),
+                &mut self.inner,
+            );
+        }
+    }
+
     /// Shifts the digits of `lhs` by `rhs`, storing the result in `lhs`.
     ///
     /// If `rhs` is positive, shifts to the left. If `rhs` is negative, shifts

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -22,9 +22,9 @@ use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
-use serde_test::{assert_tokens, Token};
-
 use dec::{Context, Decimal128, Decimal32, Decimal64, OrderedDecimal, Status};
+#[cfg(feature = "arbitrary-precision")]
+use serde_test::{assert_tokens, Token};
 
 #[derive(Default)]
 struct ValidatingHasher {
@@ -208,6 +208,7 @@ fn test_overloading() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(feature = "arbitrary-precision")]
 fn test_i64_to_decnum() -> Result<(), Box<dyn Error>> {
     use dec::Decimal;
     const N: usize = 12;
@@ -227,6 +228,7 @@ fn test_i64_to_decnum() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(feature = "arbitrary-precision")]
 fn test_u64_to_decnum() -> Result<(), Box<dyn Error>> {
     use dec::Decimal;
     const N: usize = 12;
@@ -245,6 +247,7 @@ fn test_u64_to_decnum() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(feature = "arbitrary-precision")]
 fn test_i128_to_decnum() -> Result<(), Box<dyn Error>> {
     use dec::Decimal;
     const N: usize = 12;
@@ -315,6 +318,7 @@ fn test_i128_to_decnum() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(feature = "arbitrary-precision")]
 fn test_u128_to_decnum() -> Result<(), Box<dyn Error>> {
     use dec::Decimal;
     const N: usize = 12;

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -959,3 +959,30 @@ fn test_decimal128_rescale() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+#[cfg(feature = "arbitrary-precision")]
+fn test_precision_decnum() {
+    const N: usize = 12;
+    fn inner(v: &str, p: u64) {
+        let mut cx_n = Context::<dec::Decimal<N>>::default();
+        let v_n = cx_n.parse(v).unwrap();
+        assert_eq!(v_n.precision(), p);
+    }
+    inner("1", 1);
+    inner("10", 2);
+    inner("1e2", 3);
+    inner("1e-2", 2);
+    inner("1.2", 2);
+    inner("1.2e-2", 3);
+    inner("12e-2", 2);
+    inner("1e40", 41);
+    inner("1e-40", 40);
+    inner("0", 1);
+    // The leading zero gets folded into the exponent, i.e. 1E-1
+    inner("0.1", 1);
+    // This is still only 1 digit of precision because of its equivalence to
+    // 0E-1
+    inner("0.0", 1);
+    inner("0.0000", 4);
+}

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -977,6 +977,39 @@ fn test_standard_notation_dec_128() {
 }
 
 #[test]
+#[cfg(feature = "arbitrary-precision")]
+fn test_standard_notation_decnum() {
+    use dec::Decimal;
+    const N: usize = 12;
+    // Test output on summed numbers
+    fn sum_inner(l: &str, r: &str) {
+        let mut cx = Context::<Decimal<N>>::default();
+        let l = cx.parse(l).unwrap();
+        let r = cx.parse(r).unwrap();
+        let s = l + r;
+        assert_eq!(s.to_string(), s.to_standard_notation_string());
+    }
+    sum_inner("1.23", "2.34");
+    sum_inner(".123", ".234");
+    sum_inner("1.23", ".234");
+    sum_inner("1.23", "234");
+    sum_inner("1.23", ".77");
+    sum_inner("10", "2");
+    sum_inner("-1.23", "1.23");
+
+    // Test output on a div that maxes out precision
+    let mut cx = Context::<Decimal<N>>::default();
+    let d = cx.parse("1.21035").unwrap();
+    let mut r = Decimal::<N>::from(1);
+    cx.div(&mut r, &d);
+
+    assert_eq!(
+        "0.826207295410418473995125376957078531",
+        r.to_standard_notation_string()
+    );
+}
+
+#[test]
 fn test_decimal64_rescale() -> Result<(), Box<dyn Error>> {
     let mut inexact_error = Status::default();
     inexact_error.set_inexact();

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -22,6 +22,8 @@ use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
+use serde_test::{assert_tokens, Token};
+
 use dec::{Context, Decimal128, Decimal32, Decimal64, OrderedDecimal, Status};
 
 #[derive(Default)]
@@ -1163,4 +1165,81 @@ fn test_precision_decnum() {
     // 0E-1
     inner("0.0", 1);
     inner("0.0000", 4);
+}
+
+#[test]
+#[cfg(feature = "arbitrary-precision")]
+fn test_ser_de() {
+    const N: usize = 12;
+    let mut cx = Context::<dec::Decimal<N>>::default();
+    let d = cx.parse("-12.34").unwrap();
+
+    assert_tokens(
+        &d,
+        &[
+            Token::Struct {
+                name: "Decimal",
+                len: 4,
+            },
+            Token::Str("digits"),
+            Token::U32(4),
+            Token::Str("exponent"),
+            Token::I32(-2),
+            Token::Str("bits"),
+            // This is equal to decnumber_sys::DECNEG
+            Token::U8(128),
+            Token::Str("lsu"),
+            Token::Seq { len: Some(12) },
+            Token::U16(234),
+            Token::U16(1),
+            Token::U16(0),
+            Token::U16(36),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(36),
+            Token::U16(0),
+            Token::U16(36),
+            Token::SeqEnd,
+            Token::StructEnd,
+        ],
+    );
+
+    let d = cx
+        .parse("1234567890123456789012345678901234567890")
+        .unwrap();
+
+    assert_tokens(
+        &d,
+        &[
+            Token::Struct {
+                name: "Decimal",
+                len: 4,
+            },
+            Token::Str("digits"),
+            Token::U32(36),
+            Token::Str("exponent"),
+            Token::I32(4),
+            Token::Str("bits"),
+            Token::U8(0),
+            Token::Str("lsu"),
+            Token::Seq { len: Some(12) },
+            Token::U16(457),
+            Token::U16(123),
+            Token::U16(890),
+            Token::U16(567),
+            Token::U16(234),
+            Token::U16(901),
+            Token::U16(678),
+            Token::U16(345),
+            Token::U16(012),
+            Token::U16(789),
+            Token::U16(456),
+            Token::U16(123),
+            Token::SeqEnd,
+            Token::StructEnd,
+        ],
+    );
 }

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -204,6 +204,151 @@ fn test_overloading() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+#[test]
+fn test_i64_to_decnum() -> Result<(), Box<dyn Error>> {
+    use dec::Decimal;
+    const N: usize = 12;
+    fn inner(i: i64) {
+        assert_eq!(Decimal::<N>::from(i).to_string(), i.to_string());
+    }
+
+    inner(0);
+    inner(1i64);
+    inner(-1i64);
+    inner(i64::MAX);
+    inner(i64::MIN);
+    inner(i64::MAX / 2);
+    inner(i64::MIN / 2);
+
+    Ok(())
+}
+
+#[test]
+fn test_u64_to_decnum() -> Result<(), Box<dyn Error>> {
+    use dec::Decimal;
+    const N: usize = 12;
+    fn inner(i: u64) {
+        assert_eq!(Decimal::<N>::from(i).to_string(), i.to_string());
+    }
+
+    inner(0);
+    inner(1u64);
+    inner(u64::MAX);
+    inner(u64::MIN);
+    inner(u64::MAX / 2);
+    inner(u64::MIN / 2);
+
+    Ok(())
+}
+
+#[test]
+fn test_i128_to_decnum() -> Result<(), Box<dyn Error>> {
+    use dec::Decimal;
+    const N: usize = 12;
+    fn inner(input: i128, output: &str, inexact: bool) {
+        let mut cx = Context::<Decimal<N>>::default();
+        let d = cx.from_i128(input).to_string();
+        assert_eq!(d.to_string(), output);
+        assert_eq!(cx.status().inexact(), inexact);
+    }
+
+    inner(1i128, "1", false);
+    inner(-1i128, "-1", false);
+    inner(i128::from(i64::MAX), "9223372036854775807", false);
+    inner(i128::from(i64::MIN), "-9223372036854775808", false);
+    inner(i128::MAX, "1.70141183460469231731687303715884105E+38", true);
+    inner(
+        i128::MIN,
+        "-1.70141183460469231731687303715884106E+38",
+        true,
+    );
+    // +34 places is exact.
+    inner(
+        i128::MAX / 100000,
+        "1701411834604692317316873037158841",
+        false,
+    );
+    inner(
+        9_999_999_999_999_999_999_999_999_999_999_999i128,
+        "9999999999999999999999999999999999",
+        false,
+    );
+    // +36 places places can be inexact.
+    inner(
+        i128::MAX / 100,
+        "1.70141183460469231731687303715884106E+36",
+        true,
+    );
+    // +36 places can be exact.
+    inner(
+        1_000_000_000_000_000_000_000_000_000_000_000_000i128,
+        "1.00000000000000000000000000000000000E+36",
+        false,
+    );
+    // -34 places is exact.
+    inner(
+        i128::MIN / 100000,
+        "-1701411834604692317316873037158841",
+        false,
+    );
+    inner(
+        -9_999_999_999_999_999_999_999_999_999_999_999i128,
+        "-9999999999999999999999999999999999",
+        false,
+    );
+    // -36 places can be inexact.
+    inner(
+        i128::MIN / 100,
+        "-1.70141183460469231731687303715884106E+36",
+        true,
+    );
+    // -36 places can be exact.
+    inner(
+        -1_000_000_000_000_000_000_000_000_000_000_000_000i128,
+        "-1.00000000000000000000000000000000000E+36",
+        false,
+    );
+    Ok(())
+}
+
+#[test]
+fn test_u128_to_decnum() -> Result<(), Box<dyn Error>> {
+    use dec::Decimal;
+    const N: usize = 12;
+    fn inner(input: u128, output: &str, inexact: bool) {
+        let mut cx = Context::<Decimal<N>>::default();
+        let d = cx.from_u128(input).to_string();
+        assert_eq!(d.to_string(), output);
+        assert_eq!(cx.status().inexact(), inexact);
+    }
+    inner(1u128, "1", false);
+    inner(u128::MAX, "3.40282366920938463463374607431768211E+38", true);
+    inner(u128::MIN, "0", false);
+    // 34 places is exact.
+    inner(
+        u128::MAX / 100000,
+        "3402823669209384634633746074317682",
+        false,
+    );
+    inner(
+        9_999_999_999_999_999_999_999_999_999_999_999u128,
+        "9999999999999999999999999999999999",
+        false,
+    );
+    // 36 places can be exact.
+    inner(
+        1_000_000_000_000_000_000_000_000_000_000_000_000u128,
+        "1.00000000000000000000000000000000000E+36",
+        false,
+    );
+    // 36 places can be inexact.
+    inner(
+        1_000_000_000_000_000_000_000_000_000_000_000_001u128,
+        "1.00000000000000000000000000000000000E+36",
+        true,
+    );
+    Ok(())
+}
 
 #[test]
 fn test_i64_to_decimal128() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
@benesch Tried to atomize this as painstakingly small as possible given the size of the diff. In chatting with Eli, the idea was to make things work over being incredibly efficient because we're still in the MVP stage of getting the library into Materialize, e.g. `to_standard_notation_string`.

I also had a few hiccups with `serde` that I couldn't iron out from their docs, e.g. do we need both `visit_seq` and `visit_map`?

Anyway, let me know if there's anything else I can do to help ease this review's pain.