### PR TITLE
dec: fix Hash for OrderedDecimal<Decimal<N>>

### DIFF
--- a/dec/src/ordered.rs
+++ b/dec/src/ordered.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::convert::TryFrom;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::{Product, Sum};
@@ -212,7 +213,9 @@ impl<const N: usize> Hash for OrderedDecimal<Decimal<N>> {
         d.digits.hash(state);
         d.exponent.hash(state);
         d.bits.hash(state);
-        d.lsu.hash(state);
+        // Each element of lsu is a BCD (i.e. 3 digits wide)
+        let lsu_idx = usize::try_from(d.digits()).unwrap() / 3;
+        d.lsu[0..lsu_idx + 1].hash(state);
     }
 }
 

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -51,6 +51,7 @@ where
 const ORDERING_TESTS: &[(&str, &str, Ordering)] = &[
     ("1.2", "1.2", Ordering::Equal),
     ("1.2", "1.200", Ordering::Equal),
+    ("1.2", "1.2000000000000000000000", Ordering::Equal),
     ("1", "2", Ordering::Less),
     ("2", "1", Ordering::Greater),
     ("1", "NaN", Ordering::Less),
@@ -110,7 +111,7 @@ fn test_ordered_decimal() -> Result<(), Box<dyn Error>> {
         if lhs == rhs && hash_data(&lhs) != hash_data(&rhs) {
             panic!("{} and {} are equal but hashes are not equal", lhs, rhs);
         } else if lhs != rhs && hash_data(&lhs) == hash_data(&rhs) {
-            panic!("{} and {} are equal but hashes are equal", lhs, rhs);
+            panic!("{} and {} are not equal but hashes are equal", lhs, rhs);
         }
     }
     Ok(())


### PR DESCRIPTION
Decimal<N>'s internal BCD vec is only valid for its number of
digits/3. Previously, we calculated OrderedDecimal<Decimal<N>>
values' hashes using the entire BCD vec (i.e. not only the valid
elements), which generated an inconsistent hash for equivalent
representations of the same value.