### PR TITLE
Support converting Decimal<N> to primitive int

### DIFF
--- a/dec/src/error.rs
+++ b/dec/src/error.rs
@@ -70,3 +70,16 @@ impl fmt::Display for TryFromDecimalError {
 }
 
 impl Error for TryFromDecimalError {}
+
+/// An error indicating that a value's coefficient cannot be cast to a primitive
+/// type.
+#[derive(Debug, Eq, PartialEq)]
+pub struct InvalidCoefficientError;
+
+impl fmt::Display for InvalidCoefficientError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("decimal's coefficient cannot be expressed in target primitive type")
+    }
+}
+
+impl Error for InvalidCoefficientError {}

--- a/dec/src/error.rs
+++ b/dec/src/error.rs
@@ -52,3 +52,21 @@ impl fmt::Display for InvalidExponentError {
 }
 
 impl Error for InvalidExponentError {}
+
+/// An error indicating that a value cannot be cast to a primitive type.
+///
+/// Causes for this failure include calling cast functions on values:
+/// - Representing infinity or NaN
+/// - With non-zero exponent values
+/// - Whose coefficient doesn't fit into the target, e.g. values that require
+///   too many digits of precision.
+#[derive(Debug, Eq, PartialEq)]
+pub struct TryFromDecimalError;
+
+impl fmt::Display for TryFromDecimalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("decimal cannot be expressed in target primitive type")
+    }
+}
+
+impl Error for TryFromDecimalError {}

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -1644,3 +1644,86 @@ fn test_decnum_tryinto_primitive() {
     quantizable(1, 43, false);
     quantizable(9999, 99999999, false);
 }
+
+#[test]
+fn test_decnum_coefficient() {
+    const WIDTH: usize = 14;
+    let mut cx = Context::<Decimal<WIDTH>>::default();
+    let min_u32 = Decimal::<WIDTH>::from(u32::MIN);
+    let max_u32 = Decimal::<WIDTH>::from(u32::MAX);
+    let min_i32 = Decimal::<WIDTH>::from(i32::MIN);
+    let max_i32 = Decimal::<WIDTH>::from(i32::MAX);
+    let min_u64 = Decimal::<WIDTH>::from(u64::MIN);
+    let max_u64 = Decimal::<WIDTH>::from(u64::MAX);
+    let min_i64 = Decimal::<WIDTH>::from(i64::MIN);
+    let max_i64 = Decimal::<WIDTH>::from(i64::MAX);
+    let min_u128 = cx.from_u128(u128::MIN);
+    let max_u128 = cx.from_u128(u128::MAX);
+    let min_i128 = cx.from_i128(i128::MIN);
+    let max_i128 = cx.from_i128(i128::MAX);
+
+    let inner = |v: &Decimal<WIDTH>| {
+        let mut v = v.clone();
+        let i_u32 = v.coefficient::<u32>();
+        let i_i32 = v.coefficient::<i32>();
+        let i_u64 = v.coefficient::<u64>();
+        let i_i64 = v.coefficient::<i64>();
+        let i_u128 = v.coefficient::<u128>();
+        let i_i128 = v.coefficient::<i128>();
+
+        // u32
+        if v >= min_u32 && v <= max_u32 && !v.is_negative() {
+            assert!(i_u32.is_ok());
+        } else {
+            assert!(i_u32.is_err());
+        }
+
+        // i32
+        if v >= min_i32 && v <= max_i32 {
+            assert!(i_i32.is_ok());
+        } else {
+            assert!(i_i32.is_err());
+        }
+
+        // u64
+        if v >= min_u64 && v <= max_u64 && !v.is_negative() {
+            assert!(i_u64.is_ok());
+        } else {
+            assert!(i_u64.is_err());
+        }
+
+        // i64
+        if v >= min_i64 && v <= max_i64 {
+            assert!(i_i64.is_ok());
+        } else {
+            assert!(i_i64.is_err());
+        }
+
+        // u128
+        if v >= min_u128 && v <= max_u128 && !v.is_negative() {
+            assert!(i_u128.is_ok());
+        } else {
+            assert!(i_u128.is_err());
+        }
+
+        // i128
+        if v >= min_i128 && v <= max_i128 {
+            assert!(i_i128.is_ok());
+        } else {
+            assert!(i_i128.is_err());
+        }
+    };
+
+    inner(&min_u32);
+    inner(&max_u32);
+    inner(&min_i32);
+    inner(&max_i32);
+    inner(&min_u64);
+    inner(&max_u64);
+    inner(&min_i64);
+    inner(&max_i64);
+    inner(&min_u128);
+    inner(&max_u128);
+    inner(&min_i128);
+    inner(&max_i128);
+}


### PR DESCRIPTION
This implementation differs slightly from the approach taken in the underlying C library in that we use `checked_add` or `checked_sub` to natively handle accumulating values into their primitive type, whereas the C library does some hokey-pokey by accumulating the value mod 10 and tracking the least significant digit separately. I implemented a pretty faithful transliteration of the C approach, but it performed ~10% worse than the approach in this PR.

@benesch Given that the volume of tests is becoming unwieldy, would you suggest breaking the tests down into a file for each type? Or do you think this isn't at the breaking point yet?