### PR TITLE
dec: support to_standard_notation_string for non-finite values

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning].
 
 ## Unreleased
 
+* Fix a bug that caused all `to_standard_notation_string` implementations to
+  hang on non-finite values, e.g. `NaN`.
+
 * Remove the `arbitrary-precision` feature. The arbitrary-precision `Decimal`
   type is now always compiled.
 

--- a/dec/src/conv.rs
+++ b/dec/src/conv.rs
@@ -89,6 +89,9 @@ macro_rules! __decimal_from_int {
 /// Converts from some decimal into a string in standard notation.
 macro_rules! to_standard_notation_string {
     ($d:expr) => {{
+        if !$d.is_finite() {
+            return $d.to_string();
+        }
         let digits = $d.coefficient_digits();
         let digits = {
             let i = digits

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -884,6 +884,16 @@ fn test_standard_notation_dec_64() {
             ),
         ],
     );
+
+    fn special_value_inner(s: &str, f: fn(&Decimal64) -> bool) {
+        let mut cx = Context::<Decimal64>::default();
+        let d = cx.parse(s).unwrap();
+        assert_eq!(d.to_string(), d.to_standard_notation_string());
+        assert!(f(&d));
+    }
+    special_value_inner("NaN", Decimal64::is_nan);
+    special_value_inner("Infinity", Decimal64::is_infinite);
+    special_value_inner("-Infinity", Decimal64::is_infinite);
 }
 
 #[test]
@@ -993,6 +1003,16 @@ fn test_standard_notation_dec_128() {
             ),
         ],
     );
+
+    fn special_value_inner(s: &str, f: fn(&Decimal128) -> bool) {
+        let mut cx = Context::<Decimal128>::default();
+        let d = cx.parse(s).unwrap();
+        assert_eq!(d.to_string(), d.to_standard_notation_string());
+        assert!(f(&d));
+    }
+    special_value_inner("NaN", Decimal128::is_nan);
+    special_value_inner("Infinity", Decimal128::is_infinite);
+    special_value_inner("-Infinity", Decimal128::is_infinite);
 }
 
 #[test]
@@ -1025,6 +1045,16 @@ fn test_standard_notation_decimal() {
         "0.826207295410418473995125376957078531",
         r.to_standard_notation_string()
     );
+
+    fn special_value_inner(s: &str, f: fn(&Decimal<N>) -> bool) {
+        let mut cx = Context::<Decimal<N>>::default();
+        let d = cx.parse(s).unwrap();
+        assert_eq!(d.to_string(), d.to_standard_notation_string());
+        assert!(f(&d));
+    }
+    special_value_inner("NaN", Decimal::<N>::is_nan);
+    special_value_inner("Infinity", Decimal::<N>::is_infinite);
+    special_value_inner("-Infinity", Decimal::<N>::is_infinite);
 }
 
 #[test]

--- a/dec/tests/serde.rs
+++ b/dec/tests/serde.rs
@@ -21,40 +21,6 @@ use dec::Context;
 fn test_serde() {
     const N: usize = 12;
     let mut cx = Context::<dec::Decimal<N>>::default();
-    let d = cx.parse("-12.34").unwrap();
-
-    assert_tokens(
-        &d,
-        &[
-            Token::Struct {
-                name: "Decimal",
-                len: 4,
-            },
-            Token::Str("digits"),
-            Token::U32(4),
-            Token::Str("exponent"),
-            Token::I32(-2),
-            Token::Str("bits"),
-            // This is equal to decnumber_sys::DECNEG
-            Token::U8(128),
-            Token::Str("lsu"),
-            Token::Seq { len: Some(12) },
-            Token::U16(234),
-            Token::U16(1),
-            Token::U16(0),
-            Token::U16(36),
-            Token::U16(0),
-            Token::U16(0),
-            Token::U16(0),
-            Token::U16(0),
-            Token::U16(0),
-            Token::U16(36),
-            Token::U16(0),
-            Token::U16(36),
-            Token::SeqEnd,
-            Token::StructEnd,
-        ],
-    );
 
     let d = cx
         .parse("1234567890123456789012345678901234567890")


### PR DESCRIPTION
`to_standard_notation_string`'s macro didn't support special values, but it should!