### PR TITLE
LSU cleanup

### DIFF
--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -736,14 +736,13 @@ impl<const N: usize> Context<Decimal<N>> {
     {
         validate_n(N);
         let c_string = CString::new(s).map_err(|_| ParseDecimalError)?;
-        let mut d = MaybeUninit::<Decimal<N>>::uninit();
-        let d = unsafe {
+        let mut d = Decimal::zero();
+        unsafe {
             decnumber_sys::decNumberFromString(
                 d.as_mut_ptr() as *mut decnumber_sys::decNumber,
                 c_string.as_ptr(),
                 &mut self.inner,
             );
-            d.assume_init()
         };
         if (self.inner.status & decnumber_sys::DEC_Conversion_syntax) != 0 {
             Err(ParseDecimalError)

--- a/dec/src/decimal32.rs
+++ b/dec/src/decimal32.rs
@@ -212,15 +212,14 @@ impl Context<Decimal32> {
         S: Into<Vec<u8>>,
     {
         let c_string = CString::new(s).map_err(|_| ParseDecimalError)?;
-        let mut d = MaybeUninit::<decnumber_sys::decSingle>::uninit();
-        let d = unsafe {
-            decnumber_sys::decSingleFromString(d.as_mut_ptr(), c_string.as_ptr(), &mut self.inner);
-            d.assume_init()
-        };
+        let mut d = Decimal32::ZERO;
+        unsafe {
+            decnumber_sys::decSingleFromString(&mut d.inner, c_string.as_ptr(), &mut self.inner);
+        }
         if (self.inner.status & decnumber_sys::DEC_Conversion_syntax) != 0 {
             Err(ParseDecimalError)
         } else {
-            Ok(Decimal32 { inner: d })
+            Ok(d)
         }
     }
 
@@ -229,12 +228,11 @@ impl Context<Decimal32> {
     /// The result may be inexact. The status fields on the context will be set
     /// appropriately if so.
     pub fn from_decimal64(&mut self, d64: Decimal64) -> Decimal32 {
-        let mut d32 = MaybeUninit::<decnumber_sys::decSingle>::uninit();
-        let d32 = unsafe {
-            decnumber_sys::decSingleFromWider(d32.as_mut_ptr(), &d64.inner, &mut self.inner);
-            d32.assume_init()
-        };
-        Decimal32 { inner: d32 }
+        let mut d32 = Decimal32::ZERO;
+        unsafe {
+            decnumber_sys::decSingleFromWider(&mut d32.inner, &d64.inner, &mut self.inner);
+        }
+        d32
     }
 
     /// Constructs a number from an arbitrary-precision decimal.
@@ -242,11 +240,10 @@ impl Context<Decimal32> {
     /// The result may be inexact. The status fields on the context will be set
     /// appropriately if so.
     pub fn from_decimal<const N: usize>(&mut self, d: &Decimal<N>) -> Decimal32 {
-        let mut d32 = MaybeUninit::<decnumber_sys::decSingle>::uninit();
-        let d32 = unsafe {
-            decnumber_sys::decimal32FromNumber(d32.as_mut_ptr(), d.as_ptr(), &mut self.inner);
-            d32.assume_init()
-        };
-        Decimal32 { inner: d32 }
+        let mut d32 = Decimal32::ZERO;
+        unsafe {
+            decnumber_sys::decimal32FromNumber(&mut d32.inner, d.as_ptr(), &mut self.inner);
+        }
+        d32
     }
 }

--- a/dec/tests/serde.rs
+++ b/dec/tests/serde.rs
@@ -21,6 +21,40 @@ use dec::Context;
 fn test_serde() {
     const N: usize = 12;
     let mut cx = Context::<dec::Decimal<N>>::default();
+    let d = cx.parse("-12.34").unwrap();
+
+    assert_tokens(
+        &d,
+        &[
+            Token::Struct {
+                name: "Decimal",
+                len: 4,
+            },
+            Token::Str("digits"),
+            Token::U32(4),
+            Token::Str("exponent"),
+            Token::I32(-2),
+            Token::Str("bits"),
+            // This is equal to decnumber_sys::DECNEG
+            Token::U8(128),
+            Token::Str("lsu"),
+            Token::Seq { len: Some(12) },
+            Token::U16(234),
+            Token::U16(1),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::U16(0),
+            Token::SeqEnd,
+            Token::StructEnd,
+        ],
+    );
 
     let d = cx
         .parse("1234567890123456789012345678901234567890")


### PR DESCRIPTION
`decNumber` only fills a decimal's LSU with as many digits as necessary, leaving the remainder of the buffer filled with uninitialized junk. This PR provides a method to set those remaining values to `0`.

This is necessary because Materialize uses row's byte representation to asses equality; these junk values make it impossible to implement e.g. `DISTINCT`.

This issue also crept up previously in testing our `serde` implementation, and this method provides a simple mechanism by which we can reinstate the test.