### PR TITLE
dec: support round for Decimal

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog], and this crate adheres to [Semantic
 Versioning].
 
+## Unreleased
+
+- Support `round` for `Decimal`.
+
 ## 0.4.0 - 2021-05-20
 
 * Add the following methods:

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -1277,6 +1277,14 @@ impl<const N: usize> Context<Decimal<N>> {
         }
     }
 
+    /// Rounds the number to an integral value using the rounding mode in the
+    /// context.
+    pub fn round(&mut self, n: &mut Decimal<N>) {
+        unsafe {
+            decnumber_sys::decNumberToIntegralExact(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+        }
+    }
+
     /// Shifts the digits of `lhs` by `rhs`, storing the result in `lhs`.
     ///
     /// If `rhs` is positive, shifts to the left. If `rhs` is negative, shifts

--- a/dectest/src/backend/decimal.rs
+++ b/dectest/src/backend/decimal.rs
@@ -292,8 +292,9 @@ impl Backend for DecimalBackend {
         Ok(lhs)
     }
 
-    fn round(&mut self, _: Self::D) -> BackendResult<Self::D> {
-        Err(BackendError::Unsupported)
+    fn round(&mut self, mut n: Self::D) -> BackendResult<Self::D> {
+        self.cx.round(&mut n);
+        Ok(n)
     }
 
     fn scaleb(&mut self, mut lhs: Self::D, rhs: Self::D) -> BackendResult<Self::D> {


### PR DESCRIPTION
Need this to support casting `rust-dec` values in Materialize to ints.