### PR TITLE
dec: support creating Decimal from raw parts

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -7,7 +7,9 @@ Versioning].
 
 ## Unreleased
 
-- Support `round` for `Decimal`.
+- Support the following `Decimal` functions:
+  - `round`
+  - `from_raw_parts`
 
 ## 0.4.0 - 2021-05-20
 

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -313,6 +313,26 @@ impl<const N: usize> Decimal<N> {
         (self.digits, self.exponent, self.bits, self.lsu)
     }
 
+    /// Returns a `Decimal::<N>` with the supplied raw parts.
+    ///
+    /// # Safety
+    ///
+    /// The raw parts must be valid according to the guarantees required by the
+    /// underlying C library, or undefined behavior can result. The easiest way
+    /// to uphold these guarantees is to ensure the raw parts originate from a
+    /// call to `Decimal::to_raw_parts`.
+    pub unsafe fn from_raw_parts(digits: u32, exponent: i32, bits: u8, lsu_in: &[u16]) -> Self {
+        let mut lsu = [0; N];
+        lsu.copy_from_slice(lsu_in);
+
+        Decimal::<N> {
+            digits,
+            exponent,
+            bits,
+            lsu,
+        }
+    }
+
     /// Returns a string of the number in standard notation, i.e. guaranteed to
     /// not be scientific notation.
     pub fn to_standard_notation_string(&self) -> String {

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -1757,3 +1757,35 @@ fn test_decnum_coefficient() {
     inner(&min_i128);
     inner(&max_i128);
 }
+
+#[test]
+fn decnum_raw_parts() {
+    fn inner(s: &str, o: Option<i128>) {
+        const N: usize = 13;
+        let mut cx = Context::<Decimal<N>>::default();
+        let d = cx.parse(s).unwrap();
+        let (digits, exponent, bits, lsu) = d.to_raw_parts();
+        let r = unsafe { Decimal::<N>::from_raw_parts(digits, exponent, bits, &lsu) };
+        if d.is_nan() {
+            assert!(r.is_nan())
+        } else {
+            assert_eq!(d, r);
+        }
+        if let Some(o) = o {
+            let o = cx.from_i128(o);
+            assert_eq!(o, d);
+        }
+    }
+    inner("1", Some(1));
+    inner("-1", Some(-1));
+    inner("0.00", Some(0));
+    inner("987654321", Some(987654321));
+    inner("-987654321", Some(-987654321));
+    inner(&i128::MAX.to_string(), Some(i128::MAX));
+    inner(&i128::MIN.to_string(), Some(i128::MIN));
+    inner("98765.4321", None);
+    inner("-98765.4321", None);
+    inner("Infinity", None);
+    inner("-Infinity", None);
+    inner("NaN", None);
+}


### PR DESCRIPTION
Note that this does, in fact, fix the issue we were seeing using byte equality in Materialize; tysm for figuring that out, @benesch 