### PR TITLE
dec: fix FFI call in Decimal64::coefficient_digits

### DIFF
--- a/dec/src/decimal64.rs
+++ b/dec/src/decimal64.rs
@@ -201,7 +201,7 @@ impl Decimal64 {
     pub fn coefficient_digits(&self) -> [u8; decnumber_sys::DECDOUBLE_Pmax] {
         let mut buf = [0u8; decnumber_sys::DECDOUBLE_Pmax];
         unsafe {
-            decnumber_sys::decDoubleGetCoefficient(&self.inner, &mut buf as *mut u8);
+            decnumber_sys::decDoubleGetCoefficient(&self.inner, buf.as_mut_ptr() as *mut u8);
         }
         buf
     }


### PR DESCRIPTION
This was fine when compiling the library, but Materialize disliked the previous expression, so making it consistent with `Decimal128::coefficient_digits`.