### PR TITLE
dec: make Decimal::coefficient_units public

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -28,6 +28,8 @@ Versioning].
   `Decimal` values. These are only quality-of-life improvements and do not
   provide any new functionality.
 
+* Make `Decimal::coefficient_units` public.
+
 ## 0.4.2 - 2021-06-04
 
 * Refactor `to_raw_parts` and `to_raw_parts` to use `&[u8]` to represent a

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -172,7 +172,7 @@ impl<const N: usize> Decimal<N> {
     /// The result is ordered with the least significant digits at index 0.
     ///
     /// [dpd]: http://speleotrove.com/decimal/dnnumb.html
-    pub(crate) fn coefficient_units(&self) -> &[u16] {
+    pub fn coefficient_units(&self) -> &[u16] {
         let units_len = Self::digits_to_lsu_elements_len(self.digits);
         &self.lsu[0..units_len]
     }


### PR DESCRIPTION
This was private largely because I didn't see a use for it to be publicly visible, but I discovered one (speeding up the encoding process for values sent over PG wire), so moving it to public.