### PR TITLE
fix compilation error for target_pointer_width=32

### DIFF
--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -1267,7 +1267,7 @@ impl<const N: usize> Context<Decimal<N>> {
     /// function.
     #[cfg(target_pointer_width = "32")]
     pub fn try_into_isize(&mut self, d: Decimal<N>) -> Result<isize, TryFromDecimalError> {
-        let d = self.try_into_i32(n)?;
+        let d = self.try_into_i32(d)?;
         Ok(d as isize)
     }
 
@@ -1303,7 +1303,7 @@ impl<const N: usize> Context<Decimal<N>> {
     /// function.
     #[cfg(target_pointer_width = "32")]
     pub fn try_into_usize(&mut self, d: Decimal<N>) -> Result<usize, TryFromDecimalError> {
-        let d = self.try_into_u32(n)?;
+        let d = self.try_into_u32(d)?;
         Ok(d as usize)
     }
 


### PR DESCRIPTION
The only [bug](https://materializeinc.slack.com/archives/CMH6PG4CW/p1624575648320000) I found during dogfood day!