### PR TITLE
dec: mark static-sized Decimal types as repr(transparent)

### DIFF
--- a/dec/src/decimal128.rs
+++ b/dec/src/decimal128.rs
@@ -53,6 +53,7 @@ use crate::error::ParseDecimalError;
 /// context, which has some performance overhead. For maximum performance when
 /// performing operations in bulk, use a long-lived context that you construct
 /// yourself.
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct Decimal128 {
     pub(crate) inner: decnumber_sys::decQuad,

--- a/dec/src/decimal32.rs
+++ b/dec/src/decimal32.rs
@@ -28,6 +28,7 @@ use crate::decimal64::Decimal64;
 use crate::error::ParseDecimalError;
 
 /// A 32-bit decimal floating-point number.
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct Decimal32 {
     pub(crate) inner: decnumber_sys::decSingle,

--- a/dec/src/decimal64.rs
+++ b/dec/src/decimal64.rs
@@ -53,6 +53,7 @@ use crate::error::ParseDecimalError;
 /// context, which has some performance overhead. For maximum performance when
 /// performing operations in bulk, use a long-lived context that you construct
 /// yourself.
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct Decimal64 {
     pub(crate) inner: decnumber_sys::decDouble,


### PR DESCRIPTION
Fixes #54 