### PR TITLE
dec: refactor *_raw_parts to represent LSU values with u16s

### DIFF
--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -12,6 +12,13 @@ Versioning].
   left. `reduce_to_place` performs the operation, as expected, and
   simultaneously performs a `reduce`.
 
+* Refactor `to_raw_parts` and `to_raw_parts` to use `&[u16]` to represent a
+  `Decimal`'s `lsu`, largely reverting the change from
+  [0.4.2](#042---2021-06-04).
+
+  The reversion addresses an oversight that would corrupt values if the LSU's
+  data was moved between machines with different endianness.
+
 ## 0.4.5 - 2021-07-29
 
 * Change `Decimal`'s API for `TryFrom<Decimal<N>> for T` where `T` are primitive

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -1953,7 +1953,7 @@ fn decnum_raw_parts() {
         let mut cx = Context::<Decimal<N>>::default();
         let d = cx.parse(s).unwrap();
         let (digits, exponent, bits, lsu) = d.to_raw_parts();
-        let r = unsafe { Decimal::<N>::from_raw_parts(digits, exponent, bits, &lsu) };
+        let r = Decimal::<N>::from_raw_parts(digits, exponent, bits, &lsu);
         if d.is_nan() {
             assert!(r.is_nan())
         } else {


### PR DESCRIPTION
The prior implementation of the raw_parts functions potentially
mangled endianness if ported across machines with different endianness.
This commit refactors this to make managing the LSU's conversion
to bytes an issue for the client.

This essentially undoes the majority of #42, which I had implemented
so as to provide an immediate LSU-to-byte transformation in the library,
rather than implementing the transformation in my application. That is
to say that #42 was over-eager and should not have been committed.

Addresses some comments from MaterializeInc/materialize#9406