### PR TITLE
Implement traits from `num-traits` for Decimal types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     - run: cd dectest && cargo run -- -b decimal ../testdata/testall.decTest
     - run: cargo test
     - run: cargo test --features=serde
+    - run: cargo test --features=num-traits
 
   lint:
     name: lint

--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -7,7 +7,9 @@ Versioning].
 
 ## Unreleased
 
-* No changes yet.
+* Implement `num_traits::{MulAdd, MulAddAssign, One, Zero}` for the
+  `Decimal`, `Decimal64`, and `Decimal128` types when the `num-traits` feature
+  is enabled.
 
 ## 0.4.8 - 2022-02-05
 

--- a/dec/CHANGELOG.md
+++ b/dec/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog], and this crate adheres to [Semantic
 Versioning].
 
+## Unreleased
+
+* No changes yet.
+
 ## 0.4.8 - 2022-02-05
 
 * Expose `TryFromDecimalError`.
+
+* Add the `repr(transparent)` attribute to the `OrderedDecimal` type.
 
 ## 0.4.7 - 2022-01-15
 

--- a/dec/Cargo.toml
+++ b/dec/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [dependencies]
 decnumber-sys = { version = "0.1.5", path = "../decnumber-sys" }
 libc = "0.2.82"
+num-traits = { version = "0.2.14", optional = true }
 serde = { version = "1.0.124", features = ["derive"], optional = true }
 static_assertions = "1.1.0"
 

--- a/dec/src/decimal128.rs
+++ b/dec/src/decimal128.rs
@@ -27,6 +27,8 @@ use std::ops::{
 use std::str::FromStr;
 
 use libc::c_char;
+#[cfg(feature = "num-traits")]
+use num_traits::{MulAdd, MulAddAssign, One, Zero};
 
 use crate::context::{Class, Context};
 use crate::decimal::Decimal;
@@ -1126,5 +1128,43 @@ impl Context<Decimal128> {
             decnumber_sys::decQuadXor(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
         }
         lhs
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl One for Decimal128 {
+    #[inline]
+    fn one() -> Self {
+        Self::ONE
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl Zero for Decimal128 {
+    #[inline]
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.is_zero()
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl MulAdd for Decimal128 {
+    type Output = Self;
+
+    fn mul_add(self, a: Self, b: Self) -> Self::Output {
+        Context::<Self>::default().fma(self, a, b)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl MulAddAssign for Decimal128 {
+    #[inline]
+    fn mul_add_assign(&mut self, a: Self, b: Self) {
+        *self = self.mul_add(a, b)
     }
 }

--- a/dec/src/decimal64.rs
+++ b/dec/src/decimal64.rs
@@ -27,6 +27,8 @@ use std::ops::{
 use std::str::FromStr;
 
 use libc::c_char;
+#[cfg(feature = "num-traits")]
+use num_traits::{MulAdd, MulAddAssign, One, Zero};
 
 use crate::context::{Class, Context};
 use crate::decimal::Decimal;
@@ -1098,5 +1100,43 @@ impl Context<Decimal64> {
             decnumber_sys::decDoubleXor(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
         }
         lhs
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl One for Decimal64 {
+    #[inline]
+    fn one() -> Self {
+        Self::ONE
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl Zero for Decimal64 {
+    #[inline]
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.is_zero()
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl MulAdd for Decimal64 {
+    type Output = Self;
+
+    fn mul_add(self, a: Self, b: Self) -> Self::Output {
+        Context::<Self>::default().fma(self, a, b)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl MulAddAssign for Decimal64 {
+    #[inline]
+    fn mul_add_assign(&mut self, a: Self, b: Self) {
+        *self = self.mul_add(a, b)
     }
 }


### PR DESCRIPTION
Adds an optional dependency on the [`num-traits`](https://github.com/rust-num/num-traits) crate, and implements some of that crate's traits for `Decimal64`, `Decimal128`, and `Decimal<N>`. 