### PR TITLE
fix stacked borrow violations

### DIFF
--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -715,8 +715,9 @@ impl<const N: usize> Neg for Decimal<N> {
     /// non-cloning method, use `Context::<N>::neg`.
     fn neg(self) -> Decimal<N> {
         let mut n = self.clone();
+        let n_ptr = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberCopyNegate(n.as_mut_ptr(), n.as_ptr());
+            decnumber_sys::decNumberCopyNegate(n_ptr, n_ptr);
         }
         n
     }
@@ -1428,64 +1429,50 @@ impl<const N: usize> Context<Decimal<N>> {
     /// `n` is negative, in which case it has the same effect as
     /// [`Context::<Decimal<N>>::minus`].
     pub fn abs(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberAbs(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberAbs(n, n, &mut self.inner);
         }
     }
 
     /// Adds `lhs` and `rhs`, storing the result in `lhs`.
     pub fn add<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberAdd(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberAdd(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Carries out the digitwise logical and of `lhs` and `rhs`, storing
     /// the result in `lhs`.
     pub fn and<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberAnd(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberAnd(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Divides `lhs` by `rhs`, storing the result in `lhs`.
     pub fn div<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberDivide(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberDivide(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Divides `lhs` by `rhs`, storing the integer part of the result in `lhs`.
     pub fn div_integer<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberDivideInteger(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberDivideInteger(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Raises *e* to the power of `n`, storing the result in `n`.
     pub fn exp(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberExp(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberExp(n, n, &mut self.inner);
         }
     }
 
@@ -1500,14 +1487,9 @@ impl<const N: usize> Context<Decimal<N>> {
         y: &Decimal<L>,
         z: &Decimal<M>,
     ) {
+        let x = x.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberFMA(
-                x.as_mut_ptr(),
-                x.as_ptr(),
-                y.as_ptr(),
-                z.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberFMA(x, x, y.as_ptr(), z.as_ptr(), &mut self.inner);
         }
     }
 
@@ -1781,30 +1763,34 @@ impl<const N: usize> Context<Decimal<N>> {
     /// Computes the digitwise logical inversion of `n`, storing the result in
     /// `n`.
     pub fn invert(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberInvert(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberInvert(n, n, &mut self.inner);
         }
     }
 
     /// Computes the natural logarithm of `n`, storing the result in `n`.
     pub fn ln(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberLn(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberLn(n, n, &mut self.inner);
         }
     }
 
     /// Computes the base-10 logarithm of `n`, storing the result in `n`.
     pub fn log10(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberLog10(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberLog10(n, n, &mut self.inner);
         }
     }
 
     /// Computes the adjusted exponent of the number, according to IEEE 754
     /// rules.
     pub fn logb(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberLogB(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberLogB(n, n, &mut self.inner);
         }
     }
 
@@ -1813,26 +1799,18 @@ impl<const N: usize> Context<Decimal<N>> {
     /// The comparison is performed using the same rules as for
     /// [`total_cmp`](Context::<Decimal128>::total_cmp).
     pub fn max<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberMax(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberMax(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Places whichever of `lhs` and `rhs` has the larger absolute value in
     /// `lhs`.
     pub fn max_abs<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberMaxMag(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberMaxMag(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
@@ -1841,26 +1819,18 @@ impl<const N: usize> Context<Decimal<N>> {
     /// The comparison is performed using the same rules as for
     /// [`total_cmp`](Context::<Decimal128>::total_cmp).
     pub fn min<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberMin(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberMin(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Places whichever of `lhs` and `rhs` has the smaller absolute value in
     /// `lhs`.
     pub fn min_abs<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberMinMag(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberMinMag(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
@@ -1873,13 +1843,9 @@ impl<const N: usize> Context<Decimal<N>> {
 
     /// Multiples `lhs` by `rhs`, storing the result in `lhs`.
     pub fn mul<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberMultiply(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberMultiply(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
@@ -1930,13 +1896,9 @@ impl<const N: usize> Context<Decimal<N>> {
     /// Carries out the digitwise logical or of `lhs` and `rhs`, storing
     /// the result in `lhs`.
     pub fn or<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberOr(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberOr(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
@@ -1975,15 +1937,17 @@ impl<const N: usize> Context<Decimal<N>> {
 
     /// Adds `n` to zero, storing the result in `n`.
     pub fn plus(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberPlus(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberPlus(n, n, &mut self.inner);
         }
     }
 
     /// Raises `x` to the power of `y`, storing the result in `x`.
     pub fn pow<const M: usize>(&mut self, x: &mut Decimal<N>, y: &Decimal<M>) {
+        let x = x.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberPower(x.as_mut_ptr(), x.as_ptr(), y.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberPower(x, x, y.as_ptr(), &mut self.inner);
         }
     }
 
@@ -2001,66 +1965,52 @@ impl<const N: usize> Context<Decimal<N>> {
     /// Rounds or pads `lhs` so that it has the same exponent as `rhs`, storing
     /// the result in `lhs`.
     pub fn quantize<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberQuantize(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberQuantize(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Reduces `n`'s coefficient to its shortest possible form without
     /// changing the value of the result, storing the result in `n`.
     pub fn reduce(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberReduce(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberReduce(n, n, &mut self.inner);
         }
     }
 
     /// Integer-divides `lhs` by `rhs`, storing the remainder in `lhs`.
     pub fn rem<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberRemainder(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberRemainder(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Like [`rem`](Context::<Decimal<N>>::rem), but uses the IEEE 754
     /// rules for remainder operations.
     pub fn rem_near<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberRemainderNear(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberRemainderNear(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Rescales `lhs` to have an exponent of `rhs`.
     pub fn rescale<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberRescale(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberRescale(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
     /// Rounds the number to an integral value using the rounding mode in the
     /// context.
     pub fn round(&mut self, n: &mut Decimal<N>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberToIntegralExact(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberToIntegralExact(n, n, &mut self.inner);
         }
     }
 
@@ -2104,13 +2054,9 @@ impl<const N: usize> Context<Decimal<N>> {
     /// `rhs` specifies the number of positions to shift, and must be a finite
     /// integer.
     pub fn shift<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberShift(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberShift(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
@@ -2122,13 +2068,9 @@ impl<const N: usize> Context<Decimal<N>> {
     /// `rhs` specifies the number of positions to rotate, and must be a finite
     /// integer.
     pub fn rotate<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberRotate(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberRotate(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
@@ -2141,20 +2083,17 @@ impl<const N: usize> Context<Decimal<N>> {
 
     /// Computes the square root of `n`, storing the result in `n`.
     pub fn sqrt<const M: usize>(&mut self, n: &mut Decimal<M>) {
+        let n = n.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberSquareRoot(n.as_mut_ptr(), n.as_ptr(), &mut self.inner);
+            decnumber_sys::decNumberSquareRoot(n, n, &mut self.inner);
         }
     }
 
     /// Subtracts `rhs` from `lhs`, storing the result in `lhs`.
     pub fn sub<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberSubtract(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberSubtract(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 
@@ -2179,6 +2118,7 @@ impl<const N: usize> Context<Decimal<N>> {
         rhs: &Decimal<M>,
     ) -> Ordering {
         validate_n(N);
+
         let mut d = MaybeUninit::<Decimal<N>>::uninit();
         let d = unsafe {
             decnumber_sys::decNumberCompareTotal(
@@ -2202,13 +2142,9 @@ impl<const N: usize> Context<Decimal<N>> {
     /// Carries out the digitwise logical xor of `lhs` and `rhs`, storing
     /// the result in `lhs`.
     pub fn xor<const M: usize>(&mut self, lhs: &mut Decimal<N>, rhs: &Decimal<M>) {
+        let lhs = lhs.as_mut_ptr();
         unsafe {
-            decnumber_sys::decNumberXor(
-                lhs.as_mut_ptr(),
-                lhs.as_ptr(),
-                rhs.as_ptr(),
-                &mut self.inner,
-            );
+            decnumber_sys::decNumberXor(lhs, lhs, rhs.as_ptr(), &mut self.inner);
         }
     }
 

--- a/dec/src/decimal128.rs
+++ b/dec/src/decimal128.rs
@@ -242,8 +242,9 @@ impl Decimal128 {
     /// Returns an equivalent number whose encoding is guaranteed to be
     /// canonical.
     pub fn canonical(mut self) -> Decimal128 {
+        let inner = &mut self.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadCanonical(&mut self.inner, &self.inner);
+            decnumber_sys::decQuadCanonical(inner, inner);
         }
         self
     }
@@ -764,16 +765,18 @@ impl Context<Decimal128> {
     ///
     /// The returned result will be canonical.
     pub fn abs(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadAbs(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadAbs(n_inner, n_inner, &mut self.inner);
         }
         n
     }
 
     /// Adds `lhs` and `rhs`.
     pub fn add(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadAdd(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadAdd(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -783,16 +786,18 @@ impl Context<Decimal128> {
     /// The operands must be valid for logical operations.
     /// See [`Decimal128::is_logical`].
     pub fn and(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadAnd(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadAnd(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Divides `lhs` by `rhs`.
     pub fn div(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadDivide(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadDivide(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -805,13 +810,9 @@ impl Context<Decimal128> {
     ///
     /// [`Status::division_impossible`]: crate::context::Status::division_impossible
     pub fn div_integer(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadDivideInteger(
-                &mut lhs.inner,
-                &lhs.inner,
-                &rhs.inner,
-                &mut self.inner,
-            );
+            decnumber_sys::decQuadDivideInteger(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -821,8 +822,9 @@ impl Context<Decimal128> {
     /// The multiplication is carried out first and is exact, so this operation
     /// only has the one, final rounding.
     pub fn fma(&mut self, mut x: Decimal128, y: Decimal128, z: Decimal128) -> Decimal128 {
+        let x_inner = &mut x.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadFMA(&mut x.inner, &x.inner, &y.inner, &z.inner, &mut self.inner);
+            decnumber_sys::decQuadFMA(x_inner, x_inner, &y.inner, &z.inner, &mut self.inner);
         }
         x
     }
@@ -832,8 +834,9 @@ impl Context<Decimal128> {
     /// The operand must be valid for logical operation.
     /// See [`Decimal128::is_logical`].
     pub fn invert(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadInvert(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadInvert(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -841,8 +844,9 @@ impl Context<Decimal128> {
     /// Computes the adjusted exponent of the number, according to IEEE 754
     /// rules.
     pub fn logb(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadLogB(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadLogB(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -852,16 +856,18 @@ impl Context<Decimal128> {
     /// The comparison is performed using the same rules as for
     /// [`Decimal128::total_cmp`].
     pub fn max(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadMax(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadMax(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Returns whichever of `lhs` and `rhs` has the largest absolute value.
     pub fn max_abs(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadMaxMag(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadMaxMag(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -871,32 +877,37 @@ impl Context<Decimal128> {
     /// The comparison is performed using the same rules as for
     /// [`Decimal128::total_cmp`].
     pub fn min(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
+
         unsafe {
-            decnumber_sys::decQuadMin(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadMin(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Returns whichever of `lhs` and `rhs` has the largest absolute value.
     pub fn min_abs(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadMinMag(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadMinMag(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Subtracts `n` from zero.
     pub fn minus(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadMinus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadMinus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
 
     /// Multiplies `lhs` by `rhs`.
     pub fn mul(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadMultiply(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadMultiply(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -905,8 +916,9 @@ impl Context<Decimal128> {
     ///
     /// This operation follows the IEEE 754 rules for the *nextDown* operation.
     pub fn next_minus(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadNextMinus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadNextMinus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -915,8 +927,9 @@ impl Context<Decimal128> {
     ///
     /// This operation follows the IEEE 754 rules for the *nextUp* operation.
     pub fn next_plus(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadNextPlus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadNextPlus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -925,8 +938,9 @@ impl Context<Decimal128> {
     ///
     /// This operation follows the IEEE 754 rules for the *nextAfter* operation.
     pub fn next_toward(&mut self, mut x: Decimal128, y: Decimal128) -> Decimal128 {
+        let x_inner = &mut x.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadNextToward(&mut x.inner, &x.inner, &y.inner, &mut self.inner);
+            decnumber_sys::decQuadNextToward(x_inner, x_inner, &y.inner, &mut self.inner);
         }
         x
     }
@@ -955,16 +969,18 @@ impl Context<Decimal128> {
 
     /// Adds `n` to zero.
     pub fn plus(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadPlus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadPlus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
 
     /// Rounds or pads `lhs` so that it has the same exponent as `rhs`.
     pub fn quantize(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadQuantize(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadQuantize(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -975,8 +991,9 @@ impl Context<Decimal128> {
     /// This removes all possible trailing zeros; some may remain when the
     /// number is very close to the most positive or most negative number.
     pub fn reduce(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadReduce(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadReduce(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -984,13 +1001,9 @@ impl Context<Decimal128> {
     /// Integer-divides `lhs` by `rhs` and returns the remainder from the
     /// division.
     pub fn rem(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadRemainder(
-                &mut lhs.inner,
-                &lhs.inner,
-                &rhs.inner,
-                &mut self.inner,
-            );
+            decnumber_sys::decQuadRemainder(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -998,13 +1011,9 @@ impl Context<Decimal128> {
     /// Like [`rem`](Context::<Decimal128>::rem), but uses the IEEE 754
     /// rules for remainder operations.
     pub fn rem_near(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadRemainderNear(
-                &mut lhs.inner,
-                &lhs.inner,
-                &rhs.inner,
-                &mut self.inner,
-            );
+            decnumber_sys::decQuadRemainderNear(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -1019,8 +1028,9 @@ impl Context<Decimal128> {
     ///
     /// If `lhs` is infinity, the result is infinity of the same sign.
     pub fn rotate(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadRotate(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadRotate(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -1028,16 +1038,18 @@ impl Context<Decimal128> {
     /// Rounds the number to an integral value using the rounding mode in
     /// the context.
     pub fn round(&mut self, mut n: Decimal128) -> Decimal128 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadToIntegralExact(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decQuadToIntegralExact(n_inner, n_inner, &mut self.inner);
         }
         n
     }
 
     /// Multiplies `x` by 10<sup>`y`</sup>.
     pub fn scaleb(&mut self, mut x: Decimal128, y: Decimal128) -> Decimal128 {
+        let x_inner = &mut x.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadScaleB(&mut x.inner, &x.inner, &y.inner, &mut self.inner);
+            decnumber_sys::decQuadScaleB(x_inner, x_inner, &y.inner, &mut self.inner);
         }
         x
     }
@@ -1059,8 +1071,9 @@ impl Context<Decimal128> {
     ///
     /// If `lhs` is infinity, the result is infinity of the same sign.
     pub fn shift(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadShift(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadShift(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -1102,8 +1115,9 @@ impl Context<Decimal128> {
 
     /// Subtracts `rhs` from `lhs`.
     pub fn sub(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadSubtract(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadSubtract(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -1113,8 +1127,9 @@ impl Context<Decimal128> {
     /// The operands must be valid for logical operations.
     /// See [`Decimal128::is_logical`].
     pub fn or(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadOr(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadOr(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -1124,8 +1139,9 @@ impl Context<Decimal128> {
     /// The operands must be valid for logical operations.
     /// See [`Decimal128::is_logical`].
     pub fn xor(&mut self, mut lhs: Decimal128, rhs: Decimal128) -> Decimal128 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decQuad;
         unsafe {
-            decnumber_sys::decQuadXor(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decQuadXor(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }

--- a/dec/src/decimal64.rs
+++ b/dec/src/decimal64.rs
@@ -714,16 +714,18 @@ impl Context<Decimal64> {
     ///
     /// The returned result will be canonical.
     pub fn abs(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleAbs(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleAbs(n_inner, n_inner, &mut self.inner);
         }
         n
     }
 
     /// Adds `lhs` and `rhs`.
     pub fn add(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleAdd(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleAdd(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -733,16 +735,18 @@ impl Context<Decimal64> {
     /// The operands must be valid for logical operations.
     /// See [`Decimal64::is_logical`].
     pub fn and(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleAnd(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleAnd(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Divides `lhs` by `rhs`.
     pub fn div(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleDivide(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleDivide(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -755,10 +759,11 @@ impl Context<Decimal64> {
     ///
     /// [`Status::division_impossible`]: crate::context::Status::division_impossible
     pub fn div_integer(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
             decnumber_sys::decDoubleDivideInteger(
-                &mut lhs.inner,
-                &lhs.inner,
+                lhs_inner,
+                lhs_inner,
                 &rhs.inner,
                 &mut self.inner,
             );
@@ -771,14 +776,9 @@ impl Context<Decimal64> {
     /// The multiplication is carried out first and is exact, so this operation
     /// only has the one, final rounding.
     pub fn fma(&mut self, mut x: Decimal64, y: Decimal64, z: Decimal64) -> Decimal64 {
+        let x_inner = &mut x.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleFMA(
-                &mut x.inner,
-                &x.inner,
-                &y.inner,
-                &z.inner,
-                &mut self.inner,
-            );
+            decnumber_sys::decDoubleFMA(x_inner, x_inner, &y.inner, &z.inner, &mut self.inner);
         }
         x
     }
@@ -788,8 +788,9 @@ impl Context<Decimal64> {
     /// The operand must be valid for logical operation.
     /// See [`Decimal64::is_logical`].
     pub fn invert(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleInvert(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleInvert(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -797,8 +798,9 @@ impl Context<Decimal64> {
     /// Computes the adjusted exponent of the number, according to IEEE 754
     /// rules.
     pub fn logb(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleLogB(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleLogB(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -808,16 +810,18 @@ impl Context<Decimal64> {
     /// The comparison is performed using the same rules as for
     /// [`Decimal64::total_cmp`].
     pub fn max(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleMax(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleMax(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Returns whichever of `lhs` and `rhs` has the largest absolute value.
     pub fn max_abs(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleMaxMag(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleMaxMag(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -827,24 +831,27 @@ impl Context<Decimal64> {
     /// The comparison is performed using the same rules as for
     /// [`Decimal64::total_cmp`].
     pub fn min(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleMin(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleMin(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Returns whichever of `lhs` and `rhs` has the largest absolute value.
     pub fn min_abs(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleMinMag(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleMinMag(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
 
     /// Subtracts `n` from zero.
     pub fn minus(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleMinus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleMinus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -866,8 +873,9 @@ impl Context<Decimal64> {
     ///
     /// This operation follows the IEEE 754 rules for the *nextDown* operation.
     pub fn next_minus(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleNextMinus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleNextMinus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -876,8 +884,9 @@ impl Context<Decimal64> {
     ///
     /// This operation follows the IEEE 754 rules for the *nextUp* operation.
     pub fn next_plus(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleNextPlus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleNextPlus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -886,8 +895,9 @@ impl Context<Decimal64> {
     ///
     /// This operation follows the IEEE 754 rules for the *nextAfter* operation.
     pub fn next_toward(&mut self, mut x: Decimal64, y: Decimal64) -> Decimal64 {
+        let x_inner = &mut x.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleNextToward(&mut x.inner, &x.inner, &y.inner, &mut self.inner);
+            decnumber_sys::decDoubleNextToward(x_inner, x_inner, &y.inner, &mut self.inner);
         }
         x
     }
@@ -917,21 +927,18 @@ impl Context<Decimal64> {
 
     /// Adds `n` to zero.
     pub fn plus(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoublePlus(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoublePlus(n_inner, n_inner, &mut self.inner);
         }
         n
     }
 
     /// Rounds or pads `lhs` so that it has the same exponent as `rhs`.
     pub fn quantize(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleQuantize(
-                &mut lhs.inner,
-                &lhs.inner,
-                &rhs.inner,
-                &mut self.inner,
-            );
+            decnumber_sys::decDoubleQuantize(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -942,8 +949,9 @@ impl Context<Decimal64> {
     /// This removes all possible trailing zeros; some may remain when the
     /// number is very close to the most positive or most negative number.
     pub fn reduce(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleReduce(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleReduce(n_inner, n_inner, &mut self.inner);
         }
         n
     }
@@ -951,13 +959,9 @@ impl Context<Decimal64> {
     /// Integer-divides `lhs` by `rhs` and returns the remainder from the
     /// division.
     pub fn rem(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleRemainder(
-                &mut lhs.inner,
-                &lhs.inner,
-                &rhs.inner,
-                &mut self.inner,
-            );
+            decnumber_sys::decDoubleRemainder(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -965,10 +969,11 @@ impl Context<Decimal64> {
     /// Like [`rem`](Context::<Decimal64>::rem), but uses the IEEE 754
     /// rules for remainder operations.
     pub fn rem_near(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
             decnumber_sys::decDoubleRemainderNear(
-                &mut lhs.inner,
-                &lhs.inner,
+                lhs_inner,
+                lhs_inner,
                 &rhs.inner,
                 &mut self.inner,
             );
@@ -986,8 +991,9 @@ impl Context<Decimal64> {
     ///
     /// If `lhs` is infinity, the result is infinity of the same sign.
     pub fn rotate(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleRotate(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleRotate(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -995,16 +1001,18 @@ impl Context<Decimal64> {
     /// Rounds the number to an integral value using the rounding mode in the
     /// context.
     pub fn round(&mut self, mut n: Decimal64) -> Decimal64 {
+        let n_inner = &mut n.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleToIntegralExact(&mut n.inner, &n.inner, &mut self.inner);
+            decnumber_sys::decDoubleToIntegralExact(n_inner, n_inner, &mut self.inner);
         }
         n
     }
 
     /// Multiplies `x` by 10<sup>`y`</sup>.
     pub fn scaleb(&mut self, mut x: Decimal64, y: Decimal64) -> Decimal64 {
+        let x_inner = &mut x.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleScaleB(&mut x.inner, &x.inner, &y.inner, &mut self.inner);
+            decnumber_sys::decDoubleScaleB(x_inner, x_inner, &y.inner, &mut self.inner);
         }
         x
     }
@@ -1026,8 +1034,9 @@ impl Context<Decimal64> {
     ///
     /// If `lhs` is infinity, the result is infinity of the same sign.
     pub fn shift(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleShift(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleShift(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -1085,8 +1094,9 @@ impl Context<Decimal64> {
     /// The operands must be valid for logical operations.
     /// See [`Decimal64::is_logical`].
     pub fn or(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleOr(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleOr(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }
@@ -1096,8 +1106,9 @@ impl Context<Decimal64> {
     /// The operands must be valid for logical operations.
     /// See [`Decimal64::is_logical`].
     pub fn xor(&mut self, mut lhs: Decimal64, rhs: Decimal64) -> Decimal64 {
+        let lhs_inner = &mut lhs.inner as *mut decnumber_sys::decDouble;
         unsafe {
-            decnumber_sys::decDoubleXor(&mut lhs.inner, &lhs.inner, &rhs.inner, &mut self.inner);
+            decnumber_sys::decDoubleXor(lhs_inner, lhs_inner, &rhs.inner, &mut self.inner);
         }
         lhs
     }


### PR DESCRIPTION
When calling a decnumber_sys function where one of the inputs is used as the output, we need to be careful to pass the *same* pointer in for both inputs, rather than constructing two different pointers, or we run afoul of the stacked borrow check in Miri.

Fix #74.
Close #75.