### PR TITLE
Make `Decimal::to_packed_bcd` take `&self`

### DIFF
--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -562,7 +562,7 @@ impl<const N: usize> Decimal<N> {
     /// (i.e. its negated exponent) or `None` for special values.
     ///
     /// [pd]: http://speleotrove.com/decimal/dnpack.html
-    pub fn to_packed_bcd(&mut self) -> Option<(Vec<u8>, i32)> {
+    pub fn to_packed_bcd(&self) -> Option<(Vec<u8>, i32)> {
         if self.is_special() {
             return None;
         }
@@ -579,7 +579,7 @@ impl<const N: usize> Decimal<N> {
                 bcd.as_mut_ptr() as *mut u8,
                 len.try_into().unwrap(),
                 &mut scale as *mut i32,
-                self.as_mut_ptr() as *mut decnumber_sys::decNumber,
+                self.as_ptr() as *const decnumber_sys::decNumber,
             )
         };
         // Null returned only for special values (already handled) or if `self`

--- a/dec/tests/dec.rs
+++ b/dec/tests/dec.rs
@@ -1983,7 +1983,7 @@ fn decnum_raw_parts_bcd() {
     fn inner(s: &str, o: Option<i128>) {
         const N: usize = 13;
         let mut cx = Context::<Decimal<N>>::default();
-        let mut d = cx.parse(s).unwrap();
+        let d = cx.parse(s).unwrap();
         let ret = d.to_packed_bcd();
         if d.is_special() {
             assert!(ret.is_none())


### PR DESCRIPTION
AFAICT the `to_packed_bcd(...)` method on `Decimal` does not need to take `&mut self` and instead can take `&self`.