### PR TITLE
add parsing variant that doesn't allocate

### DIFF
--- a/dec/benches/dec.rs
+++ b/dec/benches/dec.rs
@@ -15,7 +15,7 @@
 
 use std::convert::TryFrom;
 
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use rand::{thread_rng, Rng};
 
 use dec::{Context, Decimal, Decimal128, Decimal64};
@@ -40,6 +40,17 @@ pub fn bench_decode(c: &mut Criterion) {
     let mut cx = Context::<Decimal128>::default();
     let d128 = cx.from_i128(rng.gen());
     c.bench_function("decode_decimal128", |b| bench_decode_decimal128(d128, b));
+}
+
+pub fn bench_parse(c: &mut Criterion) {
+    let mut cx = Context::<Decimal<13>>::default();
+    c.bench_function("parse_decimal", |b| {
+        b.iter(|| {
+            black_box(cx.from_f64(black_box(f64::MIN)));
+            black_box(cx.from_f64(black_box(f64::from_bits(0x8008000000000000))));
+            black_box(cx.from_f64(black_box(f64::MAX)));
+        })
+    });
 }
 
 pub fn bench_to_string(d: Decimal128, b: &mut Bencher) {
@@ -177,5 +188,11 @@ pub fn bench_tryinto_primitive(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_decode, bench_print, bench_tryinto_primitive);
+criterion_group!(
+    benches,
+    bench_decode,
+    bench_print,
+    bench_tryinto_primitive,
+    bench_parse
+);
 criterion_main!(benches);

--- a/dec/src/decimal.rs
+++ b/dec/src/decimal.rs
@@ -1400,13 +1400,18 @@ impl<const N: usize> Context<Decimal<N>> {
     where
         S: Into<Vec<u8>>,
     {
-        validate_n(N);
         let c_string = CString::new(s).map_err(|_| ParseDecimalError)?;
+        self.parse_c_str(c_string.as_c_str())
+    }
+
+    /// Parses a number from its string representation.
+    pub fn parse_c_str(&mut self, s: &CStr) -> Result<Decimal<N>, ParseDecimalError> {
+        validate_n(N);
         let mut d = Decimal::zero();
         unsafe {
             decnumber_sys::decNumberFromString(
                 d.as_mut_ptr() as *mut decnumber_sys::decNumber,
-                c_string.as_ptr(),
+                s.as_ptr(),
                 &mut self.inner,
             );
         };

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -10,4 +10,4 @@ decnumber-sys = { path = "../decnumber-sys" }
 libc = "0.2.68"
 
 [build-dependencies]
-ctest = "0.2"
+ctest = "0.4"


### PR DESCRIPTION
This PR improves the routines that convert `f64` values into `Decimal<N>` values by avoiding allocating large strings. The performance comes from:

* Serializing the float using the scientific notation, which uses at most 24 characters as opposed to ~800 characters of the only decimal notation.
* Avoiding all roundtrips to the allocator by writing into a small stack allocated buffer

I have included a benchmark for the `from_f64` method which shows a 4x improvement:

```
parse_decimal           time:   [658.76 ns 661.73 ns 665.05 ns]                           
                        change: [-78.751% -78.645% -78.534%] (p = 0.00 < 0.05)
                        Performance has improved.
```